### PR TITLE
Adjust return value in 'FileSystemProvider' API doc

### DIFF
--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -606,7 +606,7 @@ export interface FileSystemProvider {
      * Retrieve the content of a given directory.
      * @param resource The `URI` of the directory.
      *
-     * @returns A map containing the {@link FileType} for each child resource (uri).
+     * @returns A map containing the {@link FileType} for each child resource, identified by name.
      */
     readdir(resource: URI): Promise<[string, FileType][]>;
 


### PR DESCRIPTION
Fix return value in 'FileSystemProvider' API doc, see https://github.com/eclipse-theia/theia/pull/8596/files/dac3e7ecf7b4d4a0c3558fed86334c941e3288fd#r504758034

Signed-off-by: Stefan Dirix <sdirix@eclipsesource.com>
Contributed on behalf of STMicroelectronics