### PR TITLE
WIP: Electron startup performance measurement script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dev-packages/electron/compile_commands.json
 .eslintcache
 scripts/download
 license-check-summary.txt*
+*-trace.json

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "test:theia": "lerna run --scope \"@theia/!(example-)*\" test --stream --concurrency=1",
     "watch": "concurrently --kill-others -n tsc,browser,electron -c red,yellow,blue \"tsc -b -w --preserveWatchOutput\" \"yarn --cwd examples/browser watch:bundle\" \"yarn --cwd examples/electron watch:bundle\"",
     "watch:compile": "concurrently --kill-others -n cleanup,tsc -c magenta,red \"ts-clean dev-packages/* packages/* -w\" \"tsc -b -w --preserveWatchOutput\"",
-    "performance:startup": "concurrently --success first -k -r \"cd scripts/performance && node measure-performance.js --name Startup --folder startup --runs 10\" \"yarn --cwd examples/browser start\""
+    "performance:startup": "concurrently --success first -k -r \"cd scripts/performance && node measure-performance.js --name Startup --folder startup --runs 10\" \"yarn --cwd examples/browser start\"",
+    "performance:electron": "yarn electron rebuild && cd scripts/performance && node electron-performance.js"
   },
   "workspaces": [
     "dev-packages/*",

--- a/scripts/performance/.gitignore
+++ b/scripts/performance/.gitignore
@@ -3,3 +3,4 @@ workspace
 *.csv
 *.json
 !base-package.json
+!electron-trace-config.json

--- a/scripts/performance/common-performance.js
+++ b/scripts/performance/common-performance.js
@@ -1,0 +1,197 @@
+/********************************************************************************
+ * Copyright (C) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+
+/**
+ * An event in the performance trace (from the Chrome performance API).
+ * @typedef TraceEvent
+ * @property {number} ts the timestamp, in microseconds since some time after host system start
+ */
+
+/**
+ * A call-back that selects an event from the performance trace.
+ * 
+ * @callback EventPredicate
+ * @param {TraceEvent} event an event to test
+ * @returns {boolean} whether the predicate selects the `event`
+ */
+
+/**
+ * A call-back that runs the test scenario to be analyzed.
+ * 
+ * @async
+ * @callback TestFunction
+ * @param {number} runNr the current run index of the multiple runs being executed
+ * @returns {PromiseLike<string>} the path to the recorded performance profiling trace file
+ */
+
+const fs = require('fs');
+
+const performanceTag = braceText('Performance');
+
+/**
+ * Measure the performance of a `test` function implementing some `scenario` of interest.
+ * 
+ * @param {string} name the application name to measure
+ * @param {string} scenario a label for the scenario being measured
+ * @param {number} runs the number of times to run the `test` scenario
+ * @param {TestFunction} test a function that executes the `scenario` to be measured, returning the file 
+ *        that records the performance profile trace
+ * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
+ * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
+ */
+async function measure(name, scenario, runs, test, isStartEvent, isEndEvent) {
+    const durations = [];
+    for (let i = 0; i < runs; i++) {
+        const runNr = i + 1;
+
+        const file = await test(runNr);
+        const time = await analyzeTrace(file, isStartEvent, isEndEvent);
+
+        durations.push(time);
+        logDuration(name, runNr, scenario, time, runs > 1);
+    }
+
+    logSummary(name, scenario, durations);
+}
+
+
+/**
+ * Log a summary of the given measured `durations`.
+ * 
+ * @param {string} name the performance script name
+ * @param {string} scenario the scenario that was measured
+ * @param {number[]} durations the measurements captured for the `scenario`
+ */
+function logSummary(name, scenario, durations) {
+    if (durations.length > 1) {
+        const mean = calculateMean(durations);
+        const stdev = calculateStandardDeviation(mean, durations);
+        logDuration(name, 'MEAN', scenario, mean);
+        logDuration(name, 'STDEV', scenario, stdev);
+    }
+}
+
+/**
+ * Analyze a performance trace file.
+ * 
+ * @param {string} profilePath the profiling trace file path
+ * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
+ * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
+ */
+async function analyzeTrace(profilePath, isStartEvent, isEndEvent) {
+    let startEvent;
+    const tracing = JSON.parse(fs.readFileSync(profilePath, 'utf8'));
+    const endEvents = tracing.traceEvents.filter(e => {
+        if (startEvent === undefined && isStartEvent(e)) {
+            startEvent = e;
+            return false;
+        }
+        return isEndEvent(e);
+    });
+
+    if (startEvent !== undefined && endEvents.length > 0) {
+        return duration(endEvents[endEvents.length - 1], startEvent);
+    }
+
+    throw new Error('Could not analyze performance trace');
+}
+
+/**
+ * Compute the duration, in seconds, to an `event` from a start event.
+ * 
+ * @param {TraceEvent} event the duration end event
+ * @param {TraceEvent} startEvent the duration start event
+ * @returns the duration, in seconds
+ */
+function duration(event, startEvent) {
+    return (event.ts - startEvent.ts) / 1_000_000;
+}
+
+/**
+ * Log a `duration` measured for some scenario.
+ * 
+ * @param {string} name the performance script name
+ * @param {number|string} run the run index number, or some kind of aggregate like 'Total' or 'Avg'
+ * @param {string} metric the scenario that was measured
+ * @param {number} duration the duration, in seconds, of the measured scenario
+ * @param {boolean=} multipleRuns whether the `run` logged is one of many being logged
+ */
+function logDuration(name, run, metric, duration, multipleRuns = true) {
+    let runText = '';
+    if (multipleRuns) {
+        runText = braceText(run);
+    }
+    console.log(performanceTag + braceText(name) + runText + ' ' + metric + ': ' + duration.toFixed(3) + ' seconds');
+}
+
+/**
+ * Compute the arithmetic mean of an `array` of numbers.
+ * 
+ * @param {number[]} array an array of numbers to average
+ * @returns the average of the `array`
+ */
+function calculateMean(array) {
+    let sum = 0;
+    array.forEach(x => {
+        sum += x;
+    });
+    return (sum / array.length);
+};
+
+/**
+ * Compute the standard deviation from the mean of an `array` of numbers.
+ * 
+ * @param {number[]} array an array of numbers
+ * @returns the standard deviation of the `array` from its mean
+ */
+function calculateStandardDeviation(mean, array) {
+    let sumOfDiffsSquared = 0;
+    array.forEach(time => {
+        sumOfDiffsSquared += Math.pow((time - mean), 2)
+    });
+    const variance = sumOfDiffsSquared / array.length;
+    return Math.sqrt(variance);
+}
+
+/**
+ * Surround a string of `text` in square braces.
+ * 
+ * @param {string|number} text a string of text or a number that can be rendered as text
+ * @returns the `text` in braces
+ */
+function braceText(text) {
+    return '[' + text + ']';
+}
+
+/**
+ * Obtain a promise that resolves after some delay.
+ * 
+ * @param {number} time a delay, in milliseconds
+ * @returns a promise that will resolve after the given number of milliseconds
+ */
+function delay(time) {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, time)
+    });
+}
+
+module.exports = {
+    measure, analyzeTrace,
+    calculateMean, calculateStandardDeviation,
+    duration, logDuration, logSummary,
+    braceText, delay
+};

--- a/scripts/performance/electron-performance.js
+++ b/scripts/performance/electron-performance.js
@@ -1,0 +1,99 @@
+/********************************************************************************
+ * Copyright (C) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+const fs = require('fs');
+const fsx = require('fs-extra');
+const { resolve } = require('path');
+const { spawn } = require('child_process');
+const { measure, delay } = require('./common-performance');
+
+const basePath = resolve(__dirname, '../..');
+const electronExample = resolve(basePath, 'examples/electron');
+const theia = resolve(electronExample, 'node_modules/.bin/theia');
+
+let name = 'ElectronStartup';
+let condition = 'UI Ready';
+let traceFile = resolve(electronExample, 'electron-trace.json');
+let runs = 10;
+
+const traceConfigFile = resolve(__dirname, './electron-trace-config.json');
+const traceConfig = require('./electron-trace-config.json');
+
+(async () => {
+    const args = require('yargs/yargs')(process.argv.slice(2)).argv;
+    if (args.name) {
+        name = args.name.toString();
+    }
+    if (args.file) {
+        traceFile = args.file.toString();
+    }
+    if (args.runs) {
+        runs = parseInt(args.runs.toString());
+    }
+
+    await measurePerformance(name, traceFile, runs);
+})();
+
+async function measurePerformance(name, traceFile, runs) {
+    let electron;
+
+    function exitHandler(andExit = false) {
+        return () => {
+            if (electron && !electron.killed) {
+                process.kill(-electron.pid, 'SIGINT');
+            }
+            if (andExit) {
+                process.exit();
+            }
+        }
+    };
+
+    // Be sure not to leave a detached Electron child process
+    process.on('exit', exitHandler());
+    process.on('SIGINT', exitHandler(true));
+    process.on('SIGTERM', exitHandler(true));
+
+    /** @type import('./common-performance').TestFunction */
+    const testScenario = async (runNr) => {
+        electron = await launchElectron(traceConfigFile);
+
+        // Wait long enough to be sure that tracing has finished
+        await delay(traceConfig.startup_duration * 1000 * 3 / 2)
+            .then(() => process.kill(-electron.pid, 'SIGINT'));
+        electron = undefined;
+        return traceFile;
+    };
+
+    measure(name, condition, runs, testScenario, hasNonzeroTimestamp, isPreloadHidden);
+}
+
+async function launchElectron(traceConfigFile) {
+    return spawn(theia,
+        ['start', '--plugins=local-dir:../../plugins', `--trace-config-file=${traceConfigFile}`],
+        { cwd: electronExample, detached: true });
+}
+
+function hasNonzeroTimestamp(traceEvent) {
+    return traceEvent.hasOwnProperty('ts')
+        && traceEvent.ts > 0;
+}
+
+function isPreloadHidden(traceEvent) {
+    return traceEvent.cat.includes('blink')
+        && traceEvent.name === 'HitTest'
+        && traceEvent.args.hasOwnProperty('endData')
+        && traceEvent.args.endData.nodeName.startsWith('DIV class=\'theia-preload theia-hidden\'');
+}

--- a/scripts/performance/electron-trace-config.json
+++ b/scripts/performance/electron-trace-config.json
@@ -1,0 +1,12 @@
+{
+  "startup_duration": 10,
+  "result_file": "./electron-trace.json",
+  "trace_config": {
+    "included_categories": [
+      "blink"
+    ],
+    "excluded_categories": [
+      "*"
+    ]
+  }
+}


### PR DESCRIPTION
Refactor a reusable module out of the startup measurement script. Use this to build a new script measuring the start-up performance of the Electron example. That script uses the Chrome tracing facility, initialized on start-up, to determine how long it takes until the loading indicator is hidden. This is inferred from the last occurrence in the trace of a `HitTest` event on the `DIV` element that has the `theia-preload` and `theia-hidden` classes.

Contributed on behalf of STMicroelectronics.
