### PR TITLE
Fix handling of localhost links in the ExternalUriService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Change Log
+## v1.22.0 - 1/??/2022
+
+[1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)
+
+<a name="breaking_changes_1.22.0">[Breaking Changes:](#breaking_changes_1.22.0)</a>
+- [plugin] Removed deprecated fields `id` and `label` from `theia.Command`
+
 
 ## v1.21.0 - 12/16/2021
 

--- a/packages/core/src/browser/external-uri-service.ts
+++ b/packages/core/src/browser/external-uri-service.ts
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { environment } from '@theia/application-package/lib/environment';
 import { injectable } from 'inversify';
-import URI from '../common/uri';
 import { MaybePromise } from '../common/types';
+import URI from '../common/uri';
 import { Endpoint } from './endpoint';
 
 @injectable()
@@ -24,13 +25,17 @@ export class ExternalUriService {
 
     /**
      * Maps local to remote URLs.
-     * Should be no-op if the given URL is not a localhost URL.
+     * Should be no-op if the given URL is not a localhost URL or when not running in the browser.
      *
      * By default maps to an origin serving Theia.
      *
      * Use `parseLocalhost` to retrieve localhost address and port information.
      */
     resolve(uri: URI): MaybePromise<URI> {
+        if (environment.electron.is()) {
+            // nothing to resolve (window.location.hostname is empty)
+            return uri;
+        }
         const localhost = this.parseLocalhost(uri);
         if (localhost) {
             return this.toRemoteUrl(uri, localhost);

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
-import { Disposable, MaybeArray } from '@theia/core/lib/common';
+import { Disposable, MaybeArray, nls } from '@theia/core/lib/common';
 import { AbstractDialog, DialogProps, setEnabled, createIconButton, Widget, codiconArray, Key, LabelProvider } from '@theia/core/lib/browser';
 import { FileStatNode } from '../file-tree';
 import { LocationListRenderer, LocationListRendererFactory } from '../location';
@@ -244,7 +244,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
         this.appendFiltersPanel();
 
-        this.appendCloseButton('Cancel');
+        this.appendCloseButton(nls.localizeByDefault('Cancel'));
         this.appendAcceptButton(this.getAcceptButtonLabel());
 
         this.addKeyListener(this.back, Key.ENTER, () => {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -163,6 +163,22 @@
   color: var(--theia-quickInputList-focusForeground) !important;
 }
 
+.quick-input-list .monaco-list-row .codicon {
+  color: var(--theia-foreground) !important;
+  padding-left: 0px !important;
+}
+
+.quick-input-list .monaco-list-row.focused .codicon {
+  color: var(--theia-list-foreground) !important;
+}
+
+.monaco-action-bar .action-item {
+  height: var(--theia-ui-icon-font-size);
+  width: var(--theia-ui-icon-font-size);
+  margin: auto;
+  padding-right: calc(var(--theia-ui-padding) * 0.5);
+}
+
 .quick-input-list .monaco-list-row.focused .monaco-highlighted-label .highlight {
   color: var(--theia-list-focusHighlightForeground) !important;
 }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -514,17 +514,17 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
         registry.registerMenuAction(OpenEditorsContextMenu.MODIFICATION, {
             commandId: CommonCommands.CLOSE_TAB.id,
-            label: 'Close',
+            label: nls.localizeByDefault('Close'),
             order: 'a'
         });
         registry.registerMenuAction(OpenEditorsContextMenu.MODIFICATION, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
-            label: 'Close Others',
+            label: nls.localizeByDefault('Close Others'),
             order: 'b'
         });
         registry.registerMenuAction(OpenEditorsContextMenu.MODIFICATION, {
             commandId: CommonCommands.CLOSE_ALL_MAIN_TABS.id,
-            label: 'Close All',
+            label: nls.localizeByDefault('Close All'),
             order: 'c'
         });
     }

--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -407,7 +407,7 @@ class OpenHostedInstanceLinkDialog extends AbstractDialog<string> {
         this.contentNode.appendChild(messageNode);
 
         this.appendCloseButton();
-        this.openButton = this.appendAcceptButton('Open');
+        this.openButton = this.appendAcceptButton(nls.localizeByDefault('Open'));
     }
 
     showOpenNewTabAskDialog(uri: string): void {

--- a/packages/plugin-ext/src/main/browser/commands.ts
+++ b/packages/plugin-ext/src/main/browser/commands.ts
@@ -20,6 +20,7 @@ import { Command, CommandService } from '@theia/core/lib/common/command';
 import { AbstractDialog } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import * as DOMPurify from '@theia/core/shared/dompurify';
+import { nls } from '@theia/core/lib/common/nls';
 
 @injectable()
 export class OpenUriCommandHandler {
@@ -85,7 +86,7 @@ class OpenNewTabDialog extends AbstractDialog<string> {
         this.contentNode.appendChild(messageNode);
 
         this.appendCloseButton();
-        this.openButton = this.appendAcceptButton('Open');
+        this.openButton = this.appendAcceptButton(nls.localizeByDefault('Open'));
     }
 
     showOpenNewTabDialog(uri: string): void {

--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -20,6 +20,7 @@ import { AbstractDialog } from '@theia/core/lib/browser/dialogs';
 import '../../../../src/main/browser/dialogs/style/modal-notification.css';
 import { MainMessageItem, MainMessageOptions } from '../../../common/plugin-api-rpc';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { nls } from '@theia/core/lib/common/nls';
 
 export enum MessageType {
     Error = 'error',
@@ -91,7 +92,7 @@ export class ModalNotification extends AbstractDialog<string | undefined> {
         if (actions.length <= 0) {
             this.appendAcceptButton();
         } else if (!actions.some(action => action.isCloseAffordance === true)) {
-            this.appendCloseButton('Close');
+            this.appendCloseButton(nls.localizeByDefault('Close'));
         }
 
         return messageNode;

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -197,10 +197,10 @@ export class CommandsConverter {
         // we're deprecating Command.id, so it has to be optional.
         // Existing code will have compiled against a non - optional version of the field, so asserting it to exist is ok
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return KnownCommands.map((external.command || external.id)!, external.arguments, (mappedId: string, mappedArgs: any[]) =>
+        return KnownCommands.map(external.command, external.arguments, (mappedId: string, mappedArgs: any[]) =>
         ({
             id: mappedId,
-            title: external.title || external.label || ' ',
+            title: external.title || ' ',
             tooltip: external.tooltip,
             arguments: mappedArgs
         }));

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -102,7 +102,7 @@ export class CodeActionAdapter {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private static _isCommand(smth: any): smth is theia.Command {
-        return typeof (<theia.Command>smth).command === 'string' || typeof (<theia.Command>smth).id === 'string';
+        return typeof (<theia.Command>smth).command === 'string';
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -202,7 +202,7 @@ export module '@theia/plugin' {
         /**
          * The identifier of the actual command handler.
          */
-        command?: string;
+        command: string;
         /**
          * Title of the command invocation, like "Add local variable 'foo'".
          */
@@ -216,15 +216,6 @@ export module '@theia/plugin' {
          * invoked with.
          */
         arguments?: any[];
-
-        /**
-         * @deprecated use command instead
-         */
-        id?: string;
-        /**
-         * @deprecated use title instead
-         */
-        label?: string;
     }
 
     /**


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
In the ExternalUriService, use the original localhost address as a fallback when resolving links, if the 'window.location.hostname' property is not defined. This can happen for links shown in the terminal in the electron app.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the electron example app
2. Print a link to localhost in the terminal, e.g. `localhost:3000`
2. Ctrl+click on the link
3. The link should open in an external browser.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
