### PR TITLE
Add --fastStartup flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 [1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)
 
+- [plugin-ext] add --fastStartup flag to wait for frontend start to deploy the plugins. [#](https://github.com/eclipse-theia/theia/pull/) - Contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.22.0">[Breaking Changes:](#breaking_changes_1.22.0)</a>
 - [core] Removed `MarkdownRenderer` class [#10589](https://github.com/eclipse-theia/theia/pull/10589)
 - [core] `ContextKeyService` is now an interface. Extenders should extend `ContextKeyServiceDummyImpl` [#10546](https://github.com/eclipse-theia/theia/pull/10546)

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -30,7 +30,8 @@ import {
     MessageClient,
     InMemoryResources,
     messageServicePath,
-    InMemoryTextResourceResolver
+    InMemoryTextResourceResolver,
+    ClientConnectionNotifier
 } from '../common';
 import { KeybindingRegistry, KeybindingContext, KeybindingContribution } from './keybinding';
 import { FrontendApplication, FrontendApplicationContribution, DefaultFrontendApplicationContribution } from './frontend-application';
@@ -390,4 +391,8 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
         child.bind(Coordinate).toConstantValue(position);
         return child.get(BreadcrumbPopupContainer);
     });
+    bind(ClientConnectionNotifier).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<ClientConnectionNotifier>('clientConnected');
+    }).inSingletonScope();
 });

--- a/packages/core/src/common/connection-notifier.ts
+++ b/packages/core/src/common/connection-notifier.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from 'inversify';
+import * as events from 'events';
+
+export const ConnectionTimeout = Symbol('ConnectionTimeout');
+
+@injectable()
+export class ClientConnectionNotifier {
+
+    static readonly CLIENT_CONNECTED = 'clientConnected';
+
+    readonly connectionEvent = new events.EventEmitter();
+
+    currentlyConnected = false;
+
+    async clientConnected(): Promise<void> {
+        if (!this.currentlyConnected) {
+            this.currentlyConnected = true;
+            this.connectionEvent.emit(ClientConnectionNotifier.CLIENT_CONNECTED);
+        }
+    }
+
+}

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -40,6 +40,7 @@ export * from './lsp-types';
 export * from './contribution-filter';
 export * from './nls';
 export * from './numbers';
+export * from './connection-notifier';
 
 import { environment } from '@theia/application-package/lib/environment';
 export { environment };

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule, decorate, injectable } from 'inversify';
 import { ApplicationPackage } from '@theia/application-package';
 import {
     bindContributionProvider, MessageService, MessageClient, ConnectionHandler, JsonRpcConnectionHandler,
-    CommandService, commandServicePath, messageServicePath
+    CommandService, commandServicePath, messageServicePath, ClientConnectionNotifier
 } from '../common';
 import { BackendApplication, BackendApplicationContribution, BackendApplicationCliContribution, BackendApplicationServer } from './backend-application';
 import { CliManager, CliContribution } from './cli';
@@ -109,4 +109,8 @@ export const backendApplicationModule = new ContainerModule(bind => {
 
     bind(EnvironmentUtils).toSelf().inSingletonScope();
     bind(ProcessUtils).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(({container}) =>
+        new JsonRpcConnectionHandler<never>('clientConnected', () => container.get<ClientConnectionNotifier>(ClientConnectionNotifier))
+    ).inSingletonScope();
+    bind(ClientConnectionNotifier).toSelf().inSingletonScope();
 });

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -37,6 +37,7 @@ const TIMER_WARNING_THRESHOLD = 50;
 const DEFAULT_PORT = environment.electron.is() ? 0 : 3000;
 const DEFAULT_HOST = 'localhost';
 const DEFAULT_SSL = false;
+const DEFAULT_FAST_STARTUP = false;
 
 export const BackendApplicationServer = Symbol('BackendApplicationServer');
 /**
@@ -107,6 +108,7 @@ export class BackendApplicationCliContribution implements CliContribution {
     cert: string | undefined;
     certkey: string | undefined;
     projectPath: string;
+    fastStartup: boolean;
 
     configure(conf: yargs.Argv): void {
         conf.option('port', { alias: 'p', description: 'The port the backend server listens on.', type: 'number', default: DEFAULT_PORT });
@@ -115,6 +117,7 @@ export class BackendApplicationCliContribution implements CliContribution {
         conf.option('cert', { description: 'Path to SSL certificate.', type: 'string' });
         conf.option('certkey', { description: 'Path to SSL certificate key.', type: 'string' });
         conf.option(APP_PROJECT_PATH, { description: 'Sets the application project directory', default: this.appProjectPath() });
+        conf.option('fastStartup', {description: 'delay plugin deployment to decrease startup time', type: 'boolean', default: DEFAULT_FAST_STARTUP});
     }
 
     setArguments(args: yargs.Arguments): void {
@@ -124,6 +127,7 @@ export class BackendApplicationCliContribution implements CliContribution {
         this.cert = args.cert as string;
         this.certkey = args.certkey as string;
         this.projectPath = args[APP_PROJECT_PATH] as string;
+        this.fastStartup = args['fastStartup'] as boolean;
     }
 
     protected appProjectPath(): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When flag is enabled the plugin deployment will be delayed until a frontend is connected.
This way the deployment of the plugins cannot slow down the fronend loading time.
When the flag is not enabled the performance is not affected.

Contributed on behalf of STMicroelectronics

Signed-off-by: Simon Graband <sgraband@eclipsesource.com>
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
