### PR TITLE
Add Task#runOptions

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -235,6 +235,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: true
             }
         };
 
@@ -264,6 +267,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: true
             }
         };
 
@@ -291,6 +297,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: true
             }
         };
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1930,6 +1930,7 @@ export class Task {
     private taskSource: string;
     private taskGroup: TaskGroup | undefined;
     private taskPresentationOptions: theia.TaskPresentationOptions;
+    private taskRunOptions: theia.RunOptions;
     constructor(
         taskDefinition: theia.TaskDefinition,
         scope: theia.WorkspaceFolder | theia.TaskScope.Global | theia.TaskScope.Workspace,
@@ -2101,6 +2102,17 @@ export class Task {
             value = Object.create(null);
         }
         this.taskPresentationOptions = value;
+    }
+
+    get runOptions(): theia.RunOptions {
+        return this.taskRunOptions;
+    }
+
+    set runOptions(value: theia.RunOptions) {
+        if (value === null || value === undefined) {
+            value = Object.create(null);
+        }
+        this.taskRunOptions = value;
     }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10829,6 +10829,16 @@ export module '@theia/plugin' {
         clear?: boolean;
     }
 
+    /**
+     * Run options for a task.
+     */
+    export interface RunOptions {
+        /**
+         * Controls whether task variables are re-evaluated on rerun.
+         */
+        reevaluateOnRerun?: boolean;
+    }
+
     export class Task {
 
         /**
@@ -10915,6 +10925,11 @@ export module '@theia/plugin' {
          * array.
          */
         problemMatchers?: string[];
+
+        /**
+         * Run options for the task
+         */
+        runOptions: RunOptions;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add `RunOptions` interface to `theia.d.ts`.
Add `runOptions` field to `Task`.

Contributed on behalf of STMicroelectronics

Note that this only ensures compatability for the API. 
The option is currently not used. As far as i can tell, currently all variables are reevaluated on a each run. I would create a follow up ticket for the support of this option. 
Additionally, it seems like `runOptions` from a task definition in a `tasks.json` file are not parsed atm, right? I would also open a follow up for this.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
