### PR TITLE
11643 terminal second window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.31.0
+<a name="breaking_changes_1.31.0">[Breaking Changes:](#breaking_changes_1.31.0)</a>
+
+- [core] the generated webpack configuration (`gen-webpack.config.js`) now exports an array of two webpack configs instead of a single one: the first contains the config for 
+generating the main code bundle (as before), the second serves to generate a *.css file for inclusion into `secondaryWindow.html` [#11707](https://github.com/eclipse-theia/theia/pull/11707)
+
 ## v1.30.0 - 9/29/2022
 
 - [core] added functionality ot listen to keyboard layout changes [#11689](https://github.com/eclipse-theia/theia/pull/11689)

--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -42,6 +42,7 @@
     "circular-dependency-plugin": "^5.2.2",
     "compression-webpack-plugin": "^9.0.0",
     "copy-webpack-plugin": "^8.1.1",
+    "mini-css-extract-plugin": "^2.6.1",
     "css-loader": "^6.2.0",
     "electron-rebuild": "^3.2.7",
     "fs-extra": "^4.0.2",

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -16,7 +16,7 @@
 
 import * as os from 'os';
 import * as fs from 'fs-extra';
-import { ApplicationPackage } from '@theia/application-package';
+import { ApplicationPackage, FrontendModuleDescription } from '@theia/application-package';
 
 export interface GeneratorOptions {
     mode?: 'development' | 'production'
@@ -30,9 +30,9 @@ export abstract class AbstractGenerator {
         protected options: GeneratorOptions = {}
     ) { }
 
-    protected compileFrontendModuleImports(modules: Map<string, string>): string {
+    protected compileFrontendModuleImports(modules: Map<string, FrontendModuleDescription>): string {
         const splitFrontend = this.options.splitFrontend ?? this.options.mode !== 'production';
-        return this.compileModuleImports(modules, splitFrontend ? 'import' : 'require');
+        return this.compileModuleImports(new Map([...modules.entries()].map(([key, module]) => [key, module.path])), splitFrontend ? 'import' : 'require');
     }
 
     protected compileBackendModuleImports(modules: Map<string, string>): string {

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -32,7 +32,7 @@ export abstract class AbstractGenerator {
 
     protected compileFrontendModuleImports(modules: Map<string, string>): string {
         const splitFrontend = this.options.splitFrontend ?? this.options.mode !== 'production';
-        return this.compileModuleImports(new Map([...modules.entries()].map(([key, path]) => [key, path])), splitFrontend ? 'import' : 'require');
+        return this.compileModuleImports(modules, splitFrontend ? 'import' : 'require');
     }
 
     protected compileBackendModuleImports(modules: Map<string, string>): string {

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -16,7 +16,7 @@
 
 import * as os from 'os';
 import * as fs from 'fs-extra';
-import { ApplicationPackage, FrontendModuleDescription } from '@theia/application-package';
+import { ApplicationPackage } from '@theia/application-package';
 
 export interface GeneratorOptions {
     mode?: 'development' | 'production'
@@ -30,9 +30,9 @@ export abstract class AbstractGenerator {
         protected options: GeneratorOptions = {}
     ) { }
 
-    protected compileFrontendModuleImports(modules: Map<string, FrontendModuleDescription>): string {
+    protected compileFrontendModuleImports(modules: Map<string, string>): string {
         const splitFrontend = this.options.splitFrontend ?? this.options.mode !== 'production';
-        return this.compileModuleImports(new Map([...modules.entries()].map(([key, module]) => [key, module.path])), splitFrontend ? 'import' : 'require');
+        return this.compileModuleImports(new Map([...modules.entries()].map(([key, path]) => [key, path])), splitFrontend ? 'import' : 'require');
     }
 
     protected compileBackendModuleImports(modules: Map<string, string>): string {

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -18,7 +18,6 @@
 
 import { AbstractGenerator, GeneratorOptions } from './abstract-generator';
 import { existsSync, readFileSync } from 'fs';
-import * as os from 'os';
 
 export class FrontendGenerator extends AbstractGenerator {
 
@@ -247,7 +246,7 @@ module.exports = Promise.resolve()${this.compileElectronMainModuleImports(electr
     protected compileSecondaryModuleImports(secondaryWindowModules: Map<string, string>): string {
         const lines = Array.from(secondaryWindowModules.entries())
             .map(([moduleName, path]) => `    container.load(require('${path}').default);`);
-        return os.EOL + lines.join(os.EOL);
+        return '\n' + lines.join('\n');
     }
 
     protected compileSecondaryIndexJs(secondaryWindowModules: Map<string, string>): string {

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -59,6 +59,7 @@ const yargs = require('yargs');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const CompressionPlugin = require('compression-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const outputPath = path.resolve(__dirname, 'lib');
 const { mode, staticCompression }  = yargs.option('mode', {
@@ -93,7 +94,7 @@ plugins.push(new CircularDependencyPlugin({
     failOnError: false // https://github.com/nodejs/readable-stream/issues/280#issuecomment-297076462
 }));
 
-module.exports = {
+module.exports = [{
     mode,
     plugins,
     devtool: 'source-map',
@@ -117,8 +118,16 @@ module.exports = {
                 loader: 'string-replace-loader',
                 include: /node_modules[\\\\/]@phosphor[\\\\/]widgets[\\\\/]lib/,
                 options: {
-                    search: /^.*?throw new Error\\('Host is not attached.'\\).*?$/gm,
-                    replace: ''
+                    multiple: [
+                        {
+                            search: /document\\.body\\.contains\\(widget.node\\)/gm,
+                            replace: 'widget.node.ownerDocument.body.contains(widget.node)'
+                        },
+                        {
+                            search: /\\!document\\.body\\.contains\\(host\\)/gm,
+                            replace: ' !host.ownerDocument.body.contains(host)'
+                        }
+                    ]
                 }
             },
             {
@@ -218,7 +227,56 @@ module.exports = {
         warnings: true,
         children: true
     }
-};`;
+},
+{
+
+
+    mode,
+    plugins: [
+        new MiniCssExtractPlugin({
+            // Options similar to the same options in webpackOptions.output
+            // both options are optional
+            filename: "[name].css",
+            chunkFilename: "[id].css",
+        }),
+    ],
+    devtool: 'source-map',
+    entry: {
+        "secondary-window": path.resolve(__dirname, 'src-gen/frontend/secondary-index.js'),
+    },
+    output: {
+        filename: '[name].js',
+        path: outputPath,
+        devtoolModuleFilenameTemplate: 'webpack:///[resource-path]?[loaders]',
+        globalObject: 'self'
+    },
+    target: 'electron-renderer',
+    cache: staticCompression,
+    module: {
+        rules: [
+            {
+                test: /\.css$/i,
+                use: [MiniCssExtractPlugin.loader, "css-loader"]
+            }
+        ]
+    },
+    resolve: {
+        fallback: {
+            'child_process': false,
+            'crypto': false,
+            'net': false,
+            'path': require.resolve('path-browserify'),
+            'process': false,
+            'os': false,
+            'timers': false
+        },
+        extensions: ['.js']
+    },
+    stats: {
+        warnings: true,
+        children: true
+    }
+}];`;
     }
 
     protected compileUserWebpackConfig(): string {

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -229,8 +229,6 @@ module.exports = [{
     }
 },
 {
-
-
     mode,
     plugins: [
         new MiniCssExtractPlugin({

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -154,7 +154,6 @@ export class ApplicationPackage {
         return this._secondaryWindowModules;
     }
 
-
     get backendModules(): Map<string, string> {
         if (!this._backendModules) {
             this._backendModules = this.computeModules('backend');

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -32,11 +32,6 @@ export class ApplicationPackageOptions {
     readonly appTarget?: ApplicationProps.Target;
 }
 
-export interface FrontendModuleDescription {
-    readonly path: string,
-    readonly includeInSecondaryWindow: boolean
-}
-
 export type ApplicationModuleResolver = (modulePath: string) => string;
 
 export class ApplicationPackage {
@@ -94,8 +89,9 @@ export class ApplicationPackage {
         return this._pck = readJsonFile(this.packagePath);
     }
 
-    protected _frontendModules: Map<string, FrontendModuleDescription> | undefined;
-    protected _frontendElectronModules: Map<string, FrontendModuleDescription> | undefined;
+    protected _frontendModules: Map<string, string> | undefined;
+    protected _frontendElectronModules: Map<string, string> | undefined;
+    protected _secondaryWindowModules: Map<string, string> | undefined;
     protected _backendModules: Map<string, string> | undefined;
     protected _backendElectronModules: Map<string, string> | undefined;
     protected _electronMainModules: Map<string, string> | undefined;
@@ -137,83 +133,60 @@ export class ApplicationPackage {
         return new ExtensionPackage(raw, this.registry, options);
     }
 
-    get frontendModules(): Map<string, FrontendModuleDescription> {
+    get frontendModules(): Map<string, string> {
         if (!this._frontendModules) {
-            this._frontendModules = this.computeFrontendModules('frontend');
+            this._frontendModules = this.computeModules('frontend');
         }
         return this._frontendModules;
     }
 
-    get frontendElectronModules(): Map<string, FrontendModuleDescription> {
+    get frontendElectronModules(): Map<string, string> {
         if (!this._frontendElectronModules) {
-            this._frontendElectronModules = this.computeFrontendModules('frontendElectron', 'frontend');
+            this._frontendElectronModules = this.computeModules('frontendElectron', 'frontend');
         }
         return this._frontendElectronModules;
     }
 
+    get secondaryWindowModules(): Map<string, string> {
+        if (!this._secondaryWindowModules) {
+            this._secondaryWindowModules = this.computeModules('secondaryWindow');
+        }
+        return this._secondaryWindowModules;
+    }
+
+
     get backendModules(): Map<string, string> {
         if (!this._backendModules) {
-            this._backendModules = this.computeBackendModules('backend');
+            this._backendModules = this.computeModules('backend');
         }
         return this._backendModules;
     }
 
     get backendElectronModules(): Map<string, string> {
         if (!this._backendElectronModules) {
-            this._backendElectronModules = this.computeBackendModules('backendElectron', 'backend');
+            this._backendElectronModules = this.computeModules('backendElectron', 'backend');
         }
         return this._backendElectronModules;
     }
 
     get electronMainModules(): Map<string, string> {
         if (!this._electronMainModules) {
-            this._electronMainModules = this.computeBackendModules('electronMain');
+            this._electronMainModules = this.computeModules('electronMain');
         }
         return this._electronMainModules;
     }
 
-    protected computeBackendModules<P extends keyof Extension, S extends keyof Extension = P>(primary: P, secondary?: S): Map<string, string> {
-        return this.computeModules((extensionPackage, config) => {
-            if (typeof config === 'string') {
-                return paths.join(extensionPackage.name, config).split(paths.sep).join('/');
-            }
-            return undefined;
-        }, primary, secondary);
-    }
-
-    protected computeFrontendModules<P extends keyof Extension, S extends keyof Extension = P>(primary: P, secondary?: S): Map<string, FrontendModuleDescription> {
-        return this.computeModules((extensionPackage, config) => {
-            if (typeof config === 'string') {
-                return {
-                    path: paths.join(extensionPackage.name, config).split(paths.sep).join('/'),
-                    includeInSecondaryWindow: false
-                };
-            } else if (config && typeof config === 'object') {
-                const { path, includeInSecondaryWindow } = <FrontendModuleDescription>config;
-                if (typeof path === 'string') {
-                    return {
-                        path: paths.join(extensionPackage.name, path).split(paths.sep).join('/'),
-                        includeInSecondaryWindow: includeInSecondaryWindow || false
-                    };
-                }
-            }
-            return undefined;
-        }, primary, secondary);
-    }
-
-    protected computeModules<T, P extends keyof Extension, S extends keyof Extension = P>(computeConfig: (ext: ExtensionPackage, config: unknown) => T | undefined,
-        primary: P, secondary?: S):
-        Map<string, T> {
-        const result = new Map<string, T>();
+    protected computeModules<P extends keyof Extension, S extends keyof Extension = P>(primary: P, secondary?: S): Map<string, string> {
+        const result = new Map<string, string>();
         let moduleIndex = 1;
         for (const extensionPackage of this.extensionPackages) {
             const extensions = extensionPackage.theiaExtensions;
             if (extensions) {
                 for (const extension of extensions) {
-                    const configMarkup = extension[primary] || (secondary && extension[secondary]);
-                    const config = computeConfig(extensionPackage, configMarkup);
-                    if (config) {
-                        result.set(`${primary}_${moduleIndex}`, config);
+                    const modulePath = extension[primary] || (secondary && extension[secondary]);
+                    if (typeof modulePath === 'string') {
+                        const extensionPath = paths.join(extensionPackage.name, modulePath).split(paths.sep).join('/');
+                        result.set(`${primary}_${moduleIndex}`, extensionPath);
                         moduleIndex = moduleIndex + 1;
                     }
                 }
@@ -274,7 +247,7 @@ export class ApplicationPackage {
         return this.ifBrowser(this.backendModules, this.backendElectronModules);
     }
 
-    get targetFrontendModules(): Map<string, FrontendModuleDescription> {
+    get targetFrontendModules(): Map<string, string> {
         return this.ifBrowser(this.frontendModules, this.frontendElectronModules);
     }
 

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -22,6 +22,7 @@ import { NpmRegistry, PublishedNodePackage, NodePackage } from './npm-registry';
 export interface Extension {
     frontend?: string;
     frontendElectron?: string;
+    secondaryWindow?: string;
     backend?: string;
     backendElectron?: string;
     electronMain?: string;

--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -10,7 +10,7 @@ const config = require('./gen-webpack.config.js');
  * window['theia']['@theia/core/lib/common/uri'].
  * Such syntax can be used by external code, for instance, for testing.
  */
-config.module.rules.push({
+config[0].module.rules.push({
     test: /\.js$/,
     loader: require.resolve('@theia/application-manager/lib/expose-loader')
 });

--- a/packages/core/src/browser/color-application-contribution.ts
+++ b/packages/core/src/browser/color-application-contribution.ts
@@ -67,10 +67,8 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
     protected readonly toUpdate = new DisposableCollection();
     protected update(): void {
         this.toUpdate.dispose();
-
         this.windows.forEach(win => this.updateWindow(win));
-
-        this.onDidChangeEmitter.fire(undefined);
+        this.onDidChangeEmitter.fire();
     }
 
     protected updateWindow(win: Window): void {

--- a/packages/core/src/browser/color-application-contribution.ts
+++ b/packages/core/src/browser/color-application-contribution.ts
@@ -33,6 +33,7 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange = this.onDidChangeEmitter.event;
+    private readonly windows: Set<Window> = new Set();
 
     @inject(ColorRegistry)
     protected readonly colors: ColorRegistry;
@@ -52,19 +53,33 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
             this.updateThemeBackground();
         });
         this.colors.onDidChange(() => this.update());
+
+        this.registerWindow(window);
+    }
+
+    registerWindow(win: Window): Disposable {
+        this.windows.add(win);
+        this.updateWindow(win);
+        this.onDidChangeEmitter.fire();
+        return Disposable.create(() => this.windows.delete(win));
     }
 
     protected readonly toUpdate = new DisposableCollection();
     protected update(): void {
-        if (!document) {
-            return;
-        }
         this.toUpdate.dispose();
-        const theme = 'theia-' + this.themeService.getCurrentTheme().type;
-        document.body.classList.add(theme);
-        this.toUpdate.push(Disposable.create(() => document.body.classList.remove(theme)));
 
-        const documentElement = document.documentElement;
+        this.windows.forEach(win => this.updateWindow(win));
+
+        this.onDidChangeEmitter.fire(undefined);
+    }
+
+    protected updateWindow(win: Window): void {
+        const theme = 'theia-' + this.themeService.getCurrentTheme().type;
+
+        win.document.body.classList.add(theme);
+        this.toUpdate.push(Disposable.create(() => win.document.body.classList.remove(theme)));
+
+        const documentElement = win.document.documentElement;
         if (documentElement) {
             for (const id of this.colors.getColors()) {
                 const variable = this.colors.getCurrentCssVariable(id);
@@ -75,7 +90,6 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
                 }
             }
         }
-        this.onDidChangeEmitter.fire(undefined);
     }
 
     protected updateThemeBackground(): void {

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -205,41 +205,19 @@ export class FrontendApplication {
         return startupElements.length === 0 ? undefined : startupElements[0] as HTMLElement;
     }
 
-    /* vvv HOTFIX begin vvv
-     *
-     * This is a hotfix against issues eclipse/theia#6459 and gitpod-io/gitpod#875 .
-     * It should be reverted after Theia was updated to the newer Monaco.
-     */
-    protected inComposition = false;
-    /**
-     * Register composition related event listeners.
-     */
-    protected registerCompositionEventListeners(): void {
-        window.document.addEventListener('compositionstart', event => {
-            this.inComposition = true;
-        });
-        window.document.addEventListener('compositionend', event => {
-            this.inComposition = false;
-        });
-    }
-    /* ^^^ HOTFIX end ^^^ */
-
     /**
      * Register global event listeners.
      */
     protected registerEventListeners(): void {
-        this.registerCompositionEventListeners(); /* Hotfix. See above. */
         this.windowsService.onUnload(() => {
             this.stateService.state = 'closing_window';
             this.layoutRestorer.storeLayout(this);
             this.stopContributions();
         });
         window.addEventListener('resize', () => this.shell.update());
-        document.addEventListener('keydown', event => {
-            if (this.inComposition !== true) {
-                this.keybindings.run(event);
-            }
-        }, true);
+
+        this.keybindings.registerEventListeners(window);
+
         document.addEventListener('touchmove', event => { event.preventDefault(); }, { passive: false });
         // Prevent forward/back navigation by scrolling in OS X
         if (isOSX) {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1240,7 +1240,8 @@ export class ApplicationShell extends Widget {
 
         let start = 0;
         const step: FrameRequestCallback = timestamp => {
-            if (document.activeElement && widget.node.contains(document.activeElement)) {
+            const activeElement = widget.node.ownerDocument.activeElement;
+            if (activeElement && widget.node.contains(activeElement)) {
                 return;
             }
             if (!start) {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -17,7 +17,10 @@
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/terminal-frontend-module",
+      "frontend": {
+        "path": "lib/browser/terminal-frontend-module",
+        "includeInSecondaryWindow": true
+      },
       "backend": "lib/node/terminal-backend-module"
     }
   ],

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -17,10 +17,8 @@
   },
   "theiaExtensions": [
     {
-      "frontend": {
-        "path": "lib/browser/terminal-frontend-module",
-        "includeInSecondaryWindow": true
-      },
+      "frontend": "lib/browser/terminal-frontend-module",
+      "secondaryWindow": "lib/browser/terminal-frontend-module",
       "backend": "lib/node/terminal-backend-module"
     }
   ],

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -565,7 +565,9 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             const originalFunc: (entry: IntersectionObserverEntry) => void = renderService._onIntersectionChange.bind(renderService);
             const replacement = function (entry: IntersectionObserverEntry): void {
                 if (entry.target.ownerDocument !== document) {
-
+                    // in Firefox, the intersection observer always reports the widget as non-intersecting if the dom element
+                    // is in a different document from when the IntersectionObserver started observing. Since we know
+                    // that the widget is always "visible" when in a secondary window, so we mark the entry as "intersecting"
                     const patchedEvent: IntersectionObserverEntry = {
                         ...entry,
                         isIntersecting: true,
@@ -576,7 +578,6 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 }
             };
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             renderService._onIntersectionChange = replacement;
         }
 

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -18,7 +18,7 @@ import { Terminal, RendererType } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection, RpcProtocol, RequestHandler } from '@theia/core';
-import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode, codicon } from '@theia/core/lib/browser';
+import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode, codicon, ExtractableWidget } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ShellTerminalServerProxy, IShellTerminalPreferences } from '../common/shell-terminal-protocol';
@@ -46,7 +46,9 @@ export interface TerminalWidgetFactoryOptions extends Partial<TerminalWidgetOpti
 }
 
 @injectable()
-export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget {
+export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget, ExtractableWidget {
+    readonly isExtractable: boolean = true;
+    secondaryWindow: Window | undefined;
 
     static LABEL = nls.localizeByDefault('Terminal');
 
@@ -555,6 +557,29 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             return;
         }
         this.term.open(this.node);
+
+        if (isFirefox) {
+            // monkey patching intersection observer handling for secondary window support
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const renderService: any = (this.term as any)._core._renderService;
+            const originalFunc: (entry: IntersectionObserverEntry) => void = renderService._onIntersectionChange.bind(renderService);
+            const replacement = function (entry: IntersectionObserverEntry): void {
+                if (entry.target.ownerDocument !== document) {
+
+                    const patchedEvent: IntersectionObserverEntry = {
+                        ...entry,
+                        isIntersecting: true,
+                    };
+                    originalFunc(patchedEvent);
+                } else {
+                    originalFunc(entry);
+                }
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            renderService._onIntersectionChange = replacement;
+        }
+
         if (this.initialData) {
             this.term.write(this.initialData);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7883,6 +7883,13 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+mini-css-extract-plugin@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz#9a1251d15f2035c342d99a468ab9da7a0451b71e"
+  integrity sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==
+  dependencies:
+    schema-utils "^4.0.0"
+
 minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"


### PR DESCRIPTION
#### What it does
Add secondary window support for terminals

    This work is happening in the context of
    https://github.com/eclipse-theia/theia/issues/11643

    The main changes are
    - Add support for building a "secondary-window.css" file to load in the
      secondary window. Includes markup for marking frontend modules as
      contributing to the sceondary windows
    - Add keybinding listeners to secondary windows
    - Add color variables to secondary window style (theme support)
    - monkey-patch IntersectionObserver handling on Firefox to make terminal
      refresh when in secondary window
    - Extend PhosphorJS source patching to work for widget attach/detach

    Contributed on behalf of ST Microelectronics

#### How to test
Open terminal views in Theia and extract them to secondary windows. I was able to test on Windows Firefox/Chrome and inside Electron, which seems to work well. Testing on Mac and Linux would be helpful.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
