### PR TITLE
Add support for "lifecycleManagedByParent"

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -453,12 +453,10 @@ export class DebugSessionManager {
         if (session) {
             if (session.options.compoundRoot) {
                 session.options.compoundRoot.stopSession();
+            } else if (session.parentSession && session.configuration.lifecycleManagedByParent) {
+                this.terminateSession(session.parentSession);
             } else {
-                if (session.parentSession && session.configuration.lifecycleManagedByParent) {
-                    this.terminateSession(session.parentSession);
-                } else {
-                    session.stop(false, () => this.debug.terminateDebugSession(session!.id));
-                }
+                session.stop(false, () => this.debug.terminateDebugSession(session!.id));
             }
         }
     }

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -250,8 +250,9 @@ export class DebugSessionManager {
 
     protected async startCompound(options: DebugCompoundSessionOptions): Promise<boolean | undefined> {
         let configurations: DebugConfigurationSessionOptions[] = [];
+        const compoundRoot = options.compound.stopAll ? new DebugCompoundRoot() : undefined;
         try {
-            configurations = this.getCompoundConfigurations(options);
+            configurations = this.getCompoundConfigurations(options, compoundRoot);
         } catch (error) {
             this.messageService.error(error.message);
             return;
@@ -265,19 +266,25 @@ export class DebugSessionManager {
         }
 
         // Compound launch is a success only if each configuration launched successfully
-        const values = await Promise.all(configurations.map(configuration => this.startConfiguration(configuration)));
+        const values = await Promise.all(configurations.map(async configuration => {
+            const newSession = await this.startConfiguration(configuration);
+            if (newSession) {
+                compoundRoot?.onDidSessionStop(() => newSession.stop(false, () => this.debug.terminateDebugSession(newSession.id)));
+            }
+            return newSession;
+        }));
         const result = values.every(success => !!success);
         return result;
     }
 
-    protected getCompoundConfigurations(options: DebugCompoundSessionOptions): DebugConfigurationSessionOptions[] {
+    protected getCompoundConfigurations(options: DebugCompoundSessionOptions, compoundRoot: DebugCompoundRoot | undefined): DebugConfigurationSessionOptions[] {
         const compound = options.compound;
         if (!compound.configurations) {
             throw new Error(nls.localizeByDefault('Compound must have "configurations" attribute set in order to start multiple configurations.'));
         }
 
-        const compoundRoot = compound.stopAll ? new DebugCompoundRoot() : undefined;
         const configurations: DebugConfigurationSessionOptions[] = [];
+
         for (const configData of compound.configurations) {
             const name = typeof configData === 'string' ? configData : configData.name;
             if (name === compound.name) {
@@ -431,6 +438,7 @@ export class DebugSessionManager {
             await session.restart();
             return session;
         }
+
         const { options, configuration } = session;
         session.stop(isRestart, () => this.debug.terminateDebugSession(session.id));
         configuration.__restart = isRestart;
@@ -443,7 +451,15 @@ export class DebugSessionManager {
             session = this._currentSession;
         }
         if (session) {
-            session.stop(false, () => this.debug.terminateDebugSession(session!.id));
+            if (session.options.compoundRoot) {
+                session.options.compoundRoot.stopSession();
+            } else {
+                if (session.parentSession && session.configuration.lifecycleManagedByParent) {
+                    this.terminateSession(session.parentSession);
+                } else {
+                    session.stop(false, () => this.debug.terminateDebugSession(session!.id));
+                }
+            }
         }
     }
 
@@ -452,8 +468,13 @@ export class DebugSessionManager {
             this.updateCurrentSession(this._currentSession);
             session = this._currentSession;
         }
+
         if (session) {
-            return this.doRestart(session, true);
+            if (session.parentSession && session.configuration.lifecycleManagedByParent) {
+                return this.restartSession(session.parentSession);
+            } else {
+                return this.doRestart(session, true);
+            }
         }
     }
 

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -117,9 +117,6 @@ export class DebugSession implements CompositeTreeElement {
             this.connection.on('capabilities', event => this.updateCapabilities(event.body.capabilities)),
             this.breakpoints.onDidChangeMarkers(uri => this.updateBreakpoints({ uri, sourceModified: true }))
         ]);
-        if (this.options.compoundRoot) {
-            this.toDispose.push(this.options.compoundRoot.onDidSessionStop(() => this.stop(false, () => { })));
-        }
     }
 
     get onDispose(): Event<void> {
@@ -354,9 +351,6 @@ export class DebugSession implements CompositeTreeElement {
                 } catch (e) {
                     console.error('Error on disconnect', e);
                 }
-            }
-            if (!isRestart) {
-                this.options.compoundRoot?.stopSession();
             }
             callback();
         }

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -37,6 +37,8 @@ export interface DebugConfiguration {
 
     parentSession?: { id: string };
 
+    lifecycleManagedByParent?: boolean;
+
     consoleMode?: DebugConsoleMode;
 
     compact?: boolean;
@@ -77,6 +79,7 @@ export namespace DebugConfiguration {
 }
 
 export interface DebugSessionOptions {
+    lifecycleManagedByParent?: boolean;
     parentSession?: { id: string };
     consoleMode?: DebugConsoleMode;
     noDebug?: boolean;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10270,6 +10270,13 @@ export module '@theia/plugin' {
         parentSession?: DebugSession;
 
         /**
+         * Controls whether lifecycle requests like 'restart' are sent to the newly created session or its parent session.
+         * By default (if the property is false or missing), lifecycle requests are sent to the new session.
+         * This property is ignored if the session has no parent session.
+         */
+        lifecycleManagedByParent?: boolean;
+
+        /**
          * Controls whether this session should have a separate debug console or share it
          * with the parent session. Has no effect for sessions which do not have a parent session.
          * Defaults to Separate.


### PR DESCRIPTION
#### What it does
Adds support for the `lifecycleSupportedByParent` flag on debug session. Fixes #11511

#### How to test
* Install built-in javascript debugger plugin with version 1.60.1 (https://open-vsx.org/api/ms-vscode/js-debug/1.61.0/file/ms-vscode.js-debug-1.61.0.vsix). 
* Experiment with auto-attached debug sessions: I used Theia itself for testing: it includes both process with many subprocesses and also the launch.json in the repo contains composite launch configurations
* Make sure terminating debug sessions (root sessions as well as descendant sessions) shows the correct behavior as described in https://code.visualstudio.com/docs/editor/debugging#_compound-launch-configurations and https://code.visualstudio.com/api/references/vscode-api#DebugSessionOptions

Contributed on behalf of ST Microelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
