### PR TITLE
11512 add parent session

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1782,7 +1782,7 @@ export interface DebugExt {
         debugConfiguration: theia.DebugConfiguration
     ): Promise<theia.DebugConfiguration | undefined | null>;
 
-    $createDebugSession(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<string>;
+    $createDebugSession(debugConfiguration: theia.DebugConfiguration, parentSessionId: string | undefined, workspaceFolder: string | undefined): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;
 }

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -39,7 +39,7 @@ export class PluginDebugAdapterContribution {
 
     async createDebugSession(config: DebugConfiguration, workspaceFolder: string | undefined): Promise<string> {
         await this.pluginService.activateByDebug('onDebugAdapterProtocolTracker', config.type);
-        return this.debugExt.$createDebugSession(config, workspaceFolder);
+        return this.debugExt.$createDebugSession(config, config.parentSession?.id, workspaceFolder);
     }
 
     async terminateDebugSession(sessionId: string): Promise<void> {

--- a/packages/plugin-ext/src/plugin/debug/debug-ext.ts
+++ b/packages/plugin-ext/src/plugin/debug/debug-ext.ts
@@ -313,13 +313,14 @@ export class DebugExtImpl implements DebugExt {
         return undefined;
     }
 
-    async $createDebugSession(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined): Promise<string> {
+    async $createDebugSession(debugConfiguration: theia.DebugConfiguration, parentSessionId: string | undefined, workspaceFolderUri: string | undefined): Promise<string> {
         const sessionId = uuid.v4();
 
         const theiaSession: theia.DebugSession = {
             id: sessionId,
             type: debugConfiguration.type,
             name: debugConfiguration.name,
+            parentSession: parentSessionId ? this.sessions.get(parentSessionId) : undefined,
             workspaceFolder: this.toWorkspaceFolder(workspaceFolderUri),
             configuration: debugConfiguration,
             customRequest: async (command: string, args?: any) => {

--- a/packages/plugin-ext/src/plugin/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/debug/plugin-debug-adapter-session.ts
@@ -24,11 +24,7 @@ import { DebugChannel } from '@theia/debug/lib/common/debug-service';
 /**
  * Server debug adapter session.
  */
-export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
-    readonly type: string;
-    readonly name: string;
-    readonly workspaceFolder: theia.WorkspaceFolder | undefined;
-    readonly configuration: theia.DebugConfiguration;
+export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implements theia.DebugSession {
 
     constructor(
         override readonly debugAdapter: DebugAdapter,
@@ -36,12 +32,27 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
         protected readonly theiaSession: theia.DebugSession) {
 
         super(theiaSession.id, debugAdapter);
-
-        this.type = theiaSession.type;
-        this.name = theiaSession.name;
-        this.workspaceFolder = theiaSession.workspaceFolder;
-        this.configuration = theiaSession.configuration;
     }
+
+    get type(): string {
+        return this.theiaSession.type;
+    };
+
+    get name(): string {
+        return this.theiaSession.name;
+    };
+
+    get parentSession(): theia.DebugSession | undefined {
+        return this.theiaSession.parentSession;
+    };
+
+    get workspaceFolder(): theia.WorkspaceFolder | undefined {
+        return this.theiaSession.workspaceFolder;
+    };
+
+    get configuration(): theia.DebugConfiguration {
+        return this.theiaSession.configuration;
+    };
 
     override async start(channel: DebugChannel): Promise<void> {
         if (this.tracker.onWillStartSession) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10418,6 +10418,12 @@ export module '@theia/plugin' {
         readonly name: string;
 
         /**
+         * The parent session of this debug session, if it was created as a child.
+         * @see DebugSessionOptions.parentSession
+         */
+        readonly parentSession?: DebugSession;
+
+        /**
          * The workspace folder of this session or `undefined` for a folderless setup.
          */
         readonly workspaceFolder: WorkspaceFolder | undefined;


### PR DESCRIPTION
#### What it does
Adds the field `parentSession` to `theia.DebugSessions`

fixes https://github.com/eclipse-theia/theia/11512

#### How to test
Install this extension into your Theia build: 

[castletest-0.0.1.zip](https://github.com/eclipsesource/theia/files/9783827/castletest-0.0.1.zip)

the source code lives here: https://github.com/tsmaeder/castletest. The extension adds a command named "Show Active Debug Session", which outputs the name of the active debug session and it's parent session to the console.

Start debug configurations with parents (I used running Theia itself as the test case) and verify that the sessions have the proper parent. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
