### PR TITLE
vscode: Support `location` in `TerminalOptions`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -303,7 +303,7 @@ export interface TerminalServiceMain {
      * Create new Terminal with Terminal options.
      * @param options - object with parameters to create new terminal.
      */
-    $createTerminal(id: string, options: theia.TerminalOptions, isPseudoTerminal?: boolean): Promise<string>;
+    $createTerminal(id: string, options: theia.TerminalOptions, parentId?: string, isPseudoTerminal?: boolean): Promise<string>;
 
     /**
      * Send text to the terminal by id.

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -16,9 +16,9 @@
 
 import { interfaces } from '@theia/core/shared/inversify';
 import { ApplicationShell, WidgetOpenerOptions } from '@theia/core/lib/browser';
-import { TerminalOptions } from '@theia/plugin';
 import { CancellationToken } from '@theia/core/shared/vscode-languageserver-protocol';
-import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { TerminalEditorLocationOptions, TerminalOptions } from '@theia/plugin';
+import { TerminalLocation, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { TerminalServiceMain, TerminalServiceExt, MAIN_RPC_CONTEXT } from '../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../common/rpc-protocol';
@@ -122,7 +122,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
         terminal.resize(cols, rows);
     }
 
-    async $createTerminal(id: string, options: TerminalOptions, isPseudoTerminal?: boolean): Promise<string> {
+    async $createTerminal(id: string, options: TerminalOptions, parentId?: string, isPseudoTerminal?: boolean): Promise<string> {
         try {
             const terminal = await this.terminals.newTerminal({
                 id,
@@ -136,6 +136,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
                 useServerTitle: false,
                 attributes: options.attributes,
                 hideFromUser: options.hideFromUser,
+                location: this.getTerminalLocation(options, parentId),
                 isPseudoTerminal
             });
             if (options.message) {
@@ -146,6 +147,24 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
         } catch (error) {
             throw new Error('Failed to create terminal. Cause: ' + error);
         }
+    }
+
+    protected getTerminalLocation(options: TerminalOptions, parentId?: string): TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: string; } | undefined {
+        if (options.location && typeof options.location === 'number') {
+            return options.location;
+        } else if (options.location && typeof options.location === 'object') {
+            if ('parentTerminal' in options.location) {
+                if (!parentId) {
+                    throw new Error('parentTerminal is set but no parentId is provided');
+                }
+                console.log('parentId ' + parentId);
+                return { 'parentTerminal': parentId };
+            } else {
+                return options.location;
+            }
+        }
+
+        return undefined;
     }
 
     $sendText(id: string, text: string, addNewLine?: boolean): void {

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -150,14 +150,13 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
     }
 
     protected getTerminalLocation(options: TerminalOptions, parentId?: string): TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: string; } | undefined {
-        if (options.location && typeof options.location === 'number') {
+        if (options.location && typeof options.location === 'number' && Object.values(TerminalLocation).includes(options.location)) {
             return options.location;
         } else if (options.location && typeof options.location === 'object') {
             if ('parentTerminal' in options.location) {
                 if (!parentId) {
                     throw new Error('parentTerminal is set but no parentId is provided');
                 }
-                console.log('parentId ' + parentId);
                 return { 'parentTerminal': parentId };
             } else {
                 return options.location;

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -150,7 +150,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
     }
 
     protected getTerminalLocation(options: TerminalOptions, parentId?: string): TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: string; } | undefined {
-        if (options.location && typeof options.location === 'number' && Object.values(TerminalLocation).includes(options.location)) {
+        if (typeof options.location === 'number' && Object.values(TerminalLocation).includes(options.location)) {
             return options.location;
         } else if (options.location && typeof options.location === 'object') {
             if ('parentTerminal' in options.location) {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -152,6 +152,7 @@ import {
     TextDocumentChangeReason,
     InputBoxValidationSeverity,
     TerminalLink,
+    TerminalLocation,
     InlayHint,
     InlayHintKind,
     InlayHintLabelPart,
@@ -1135,7 +1136,8 @@ export function createAPIFactory(
             ExtensionKind,
             InlineCompletionItem,
             InlineCompletionList,
-            InlineCompletionTriggerKind
+            InlineCompletionTriggerKind,
+            TerminalLocation
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -85,7 +85,22 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
                 shellArgs: shellArgs
             };
         }
-        this.proxy.$createTerminal(id, options, !!pseudoTerminal);
+
+        let parentId;
+
+        if (options.location && typeof options.location === 'object' && 'parentTerminal' in options.location) {
+            const parentTerminal = options.location.parentTerminal;
+            if (parentTerminal instanceof TerminalExtImpl) {
+                for (const [k, v] of this._terminals) {
+                    if (v === parentTerminal) {
+                        parentId = k;
+                        break;
+                    }
+                }
+            }
+        }
+
+        this.proxy.$createTerminal(id, options, parentId, !!pseudoTerminal);
 
         let creationOptions: theia.TerminalOptions | theia.ExtensionTerminalOptions = options;
         // make sure to pass ExtensionTerminalOptions as creation options

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1695,6 +1695,11 @@ export class TerminalLink {
     }
 }
 
+export enum TerminalLocation {
+    Panel = 1,
+    Editor = 2
+}
+
 @es5ClassCompat
 export class FileDecoration {
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3002,6 +3002,11 @@ export module '@theia/plugin' {
         message?: string;
 
         /**
+         * The {@link TerminalLocation} or {@link TerminalEditorLocationOptions} or {@link TerminalSplitLocationOptions} for the terminal.
+         */
+        location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
+
+        /**
          * Terminal attributes. Can be useful to apply some implementation specific information.
          */
         attributes?: { [key: string]: string | null };
@@ -3067,6 +3072,11 @@ export module '@theia/plugin' {
          * control it.
          */
         pty: Pseudoterminal;
+
+        /**
+         * The {@link TerminalLocation} or {@link TerminalEditorLocationOptions} or {@link TerminalSplitLocationOptions} for the terminal.
+         */
+        location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
     }
 
     /**
@@ -3205,6 +3215,50 @@ export module '@theia/plugin' {
          * depending on OS, user settings, and localization.
          */
         constructor(startIndex: number, length: number, tooltip?: string);
+    }
+
+    /**
+     * The location of the {@link Terminal}.
+     */
+    export enum TerminalLocation {
+        /**
+         * In the terminal view
+         */
+        Panel = 1,
+        /**
+         * In the editor area
+         */
+        Editor = 2,
+    }
+
+    /**
+     * Assumes a {@link TerminalLocation} of editor and allows specifying a {@link ViewColumn} and
+     * {@link TerminalEditorLocationOptions.preserveFocus preserveFocus } property
+     */
+    export interface TerminalEditorLocationOptions {
+        /**
+         * A view column in which the {@link Terminal terminal} should be shown in the editor area.
+         * Use {@link ViewColumn.Active active} to open in the active editor group, other values are
+         * adjusted to be `Min(column, columnCount + 1)`, the
+         * {@link ViewColumn.Active active}-column is not adjusted. Use
+         * {@linkcode ViewColumn.Beside} to open the editor to the side of the currently active one.
+         */
+        viewColumn: ViewColumn;
+        /**
+         * An optional flag that when `true` will stop the {@link Terminal} from taking focus.
+         */
+        preserveFocus?: boolean;
+    }
+
+    /**
+     * Uses the parent {@link Terminal}'s location for the terminal
+     */
+    export interface TerminalSplitLocationOptions {
+        /**
+         * The parent terminal to split this terminal beside. This works whether the parent terminal
+         * is in the panel or the editor area.
+         */
+        parentTerminal: Terminal;
     }
 
     /**

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -30,13 +30,79 @@ export interface TerminalExitStatus {
     readonly code: number | undefined;
 }
 
+export type TerminalLocationOptions = TerminalLocation | TerminalEditorLocation | TerminalSplitLocation;
+
+export enum TerminalLocation {
+    Panel = 1,
+    Editor = 2
+}
+
+export interface TerminalEditorLocation {
+    readonly viewColumn: number;
+    readonly preserveFocus?: boolean;
+}
+
+export interface TerminalSplitLocation {
+    readonly parentTerminal: string;
+}
+
+export enum ViewColumn {
+    /**
+     * A *symbolic* editor column representing the currently active column. This value
+     * can be used when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value
+     * of editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Active`.
+     */
+    Active = -1,
+    /**
+     * A *symbolic* editor column representing the column to the side of the active one. This value
+     * can be used when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value
+     * of editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Beside`.
+     */
+    Beside = -2,
+    /**
+     * The first editor column.
+     */
+    One = 1,
+    /**
+     * The second editor column.
+     */
+    Two = 2,
+    /**
+     * The third editor column.
+     */
+    Three = 3,
+    /**
+     * The fourth editor column.
+     */
+    Four = 4,
+    /**
+     * The fifth editor column.
+     */
+    Five = 5,
+    /**
+     * The sixth editor column.
+     */
+    Six = 6,
+    /**
+     * The seventh editor column.
+     */
+    Seven = 7,
+    /**
+     * The eighth editor column.
+     */
+    Eight = 8,
+    /**
+     * The ninth editor column.
+     */
+    Nine = 9
+}
+
 /**
  * Terminal UI widget.
  */
 export abstract class TerminalWidget extends BaseWidget {
 
     abstract processId: Promise<number>;
-
     /**
      * Get the current executable and arguments.
      */
@@ -53,6 +119,9 @@ export abstract class TerminalWidget extends BaseWidget {
 
     /** Terminal widget can be hidden from users until explicitly shown once. */
     abstract readonly hiddenFromUser: boolean;
+
+    /** The position of the terminal widget. */
+    abstract readonly location: TerminalLocationOptions;
 
     /** The last CWD assigned to the terminal, useful when attempting getCwdURI on a task terminal fails */
     lastCwd: URI;
@@ -211,4 +280,6 @@ export interface TerminalWidgetOptions {
      * When enabled the terminal will run the process as normal but not be surfaced to the user until `Terminal.show` is called.
      */
     readonly hideFromUser?: boolean;
+
+    readonly location?: TerminalLocationOptions;
 }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -657,22 +657,18 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
                 switch (widget.location.viewColumn) {
                     case ViewColumn.Active:
                         widgetOptions.ref = this.shell.currentWidget;
-                        widgetOptions.mode = 'tab-before';
+                        widgetOptions.mode = 'tab-after';
                         break;
                     case ViewColumn.Beside:
                         widgetOptions.ref = this.shell.currentWidget;
-                        widgetOptions.mode = 'tab-after';
+                        widgetOptions.mode = 'split-right';
                         break;
                     default:
-                        const widgets = this.all.filter(t => t.isVisible);
-                        const index = widget.location.viewColumn - 1;
-                        if (index < widgets.length) {
-                            widgetOptions.ref = widgets[index];
-                            widgetOptions.mode = 'open-to-left';
-                        } else {
-                            widgetOptions.ref = widgets[widgets.length - 1];
-                            widgetOptions.mode = 'open-to-right';
-                        }
+                        widgetOptions.area = 'main';
+                        const mainAreaTerminals = this.shell.getWidgets('main').filter(w => w instanceof TerminalWidget && w.isVisible);
+                        const column = widget.location.viewColumn <= mainAreaTerminals.length ? widget.location.viewColumn : mainAreaTerminals.length;
+                        widgetOptions.mode = widget.location.viewColumn <= mainAreaTerminals.length ? 'split-left' : 'split-right';
+                        widgetOptions.ref = mainAreaTerminals[column - 1];
                 }
             }
         }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -645,7 +645,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
     // TODO: reuse WidgetOpenHandler.open
     open(widget: TerminalWidget, options?: WidgetOpenerOptions): void {
         const area = widget.location === TerminalLocation.Editor ? 'main' : 'bottom';
-        const widgetOptions: ApplicationShell.WidgetOptions = { area: area, ...(options && options.widgetOptions) };
+        const widgetOptions: ApplicationShell.WidgetOptions = { area: area, ...options?.widgetOptions };
         let preserveFocus = false;
 
         if (typeof widget.location === 'object') {
@@ -666,7 +666,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
                     default:
                         widgetOptions.area = 'main';
                         const mainAreaTerminals = this.shell.getWidgets('main').filter(w => w instanceof TerminalWidget && w.isVisible);
-                        const column = widget.location.viewColumn <= mainAreaTerminals.length ? widget.location.viewColumn : mainAreaTerminals.length;
+                        const column = Math.min(widget.location.viewColumn, mainAreaTerminals.length);
                         widgetOptions.mode = widget.location.viewColumn <= mainAreaTerminals.length ? 'split-left' : 'split-right';
                         widgetOptions.ref = mainAreaTerminals[column - 1];
                 }

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -25,7 +25,7 @@ import { ShellTerminalServerProxy, IShellTerminalPreferences } from '../common/s
 import { terminalsPath } from '../common/terminal-protocol';
 import { IBaseTerminalServer, TerminalProcessInfo } from '../common/base-terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
-import { TerminalWidgetOptions, TerminalWidget, TerminalDimensions, TerminalExitStatus } from './base/terminal-widget';
+import { TerminalWidgetOptions, TerminalWidget, TerminalDimensions, TerminalExitStatus, TerminalLocationOptions, TerminalLocation } from './base/terminal-widget';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { TerminalPreferences, TerminalRendererType, isTerminalRendererType, DEFAULT_TERMINAL_RENDERER_TYPE, CursorStyle } from './terminal-preferences';
 import URI from '@theia/core/lib/common/uri';
@@ -53,6 +53,7 @@ export interface TerminalContribution {
 export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget, ExtractableWidget {
     readonly isExtractable: boolean = true;
     secondaryWindow: Window | undefined;
+    location: TerminalLocationOptions;
 
     static LABEL = nls.localizeByDefault('Terminal');
 
@@ -127,6 +128,8 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 this.term.dispose()
             ));
         }
+
+        this.location = this.options.location || TerminalLocation.Panel;
 
         this.title.closable = true;
         this.addClass('terminal-container');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Support `location` in TerminalOptions, whereas `location` can be

- a `TerminalLocation` enum with the values `Editor` and `Panel`
- a `TerminalEditorLocationOptions` object which contains a `ViewColumn` and an optional `preserveFocus` boolean
  `ViewColumn` can be `Active`, `Besides`, or an explicit column from `One` to `Nine`
- a `TerminalSplitLocationOptions` object which contains a `parentTerminal` that is supposed to be split.

Contributed on behalf of STMicroelectronics

Fixes #11506

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* Download [test extension](https://github.com/xai/vscode-extensions/blob/main/vscode-extension-terminal-location-11506/terminal-location-extension-11506-0.0.1.zip) and copy it into the `plugins` folder.
* Start Theia and verify that the commands provided by the test extension trigger the correct[^1] behavior:
  *  `Open terminal in editor` opens a terminal in the main area
  *  `Open terminal in panel` opens a terminal in the bottom area
  *  `Open terminal with TerminalSplitLocationOptions` splits the provided parent terminal, the test extension uses the most recent one as parent argument
      _Apparently, this one is currently broken in VS Code and just opens a terminal/tab in the panel area without splitting anything_
  *  `Open terminal with TerminalEditorLocationOptions` provides quick picks for ViewColumn and PreserveFocus
     * ViewColumn 'Active' should open terminal in the current column
       _Apparently this is currently broken in VS Code, it seems to always open a tab in the first column. No idea what is actually supposed to happen - maybe tab in active column if there already is a terminal?_
     * ViewColumn 'Besides' should open a terminal to the right of the current terminal
     * ViewColumn <someNumber> should open a terminal in the specified column if possible
     * PerserveFocus specifies whether the focus should remain untouched (default is false)

[^1]: The VSCode API specification and the current behavior of VSCode seems to be misaligned and at least partly broken in VSCode.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


