### PR TITLE
Add support for theia.DebugSession.parentSession

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -380,7 +380,7 @@ export class DebugSessionManager {
     }
 
     protected async doStart(sessionId: string, options: DebugConfigurationSessionOptions): Promise<DebugSession> {
-        const parentSession = options.configuration.parentSession && this._sessions.get(options.configuration.parentSession.id);
+        const parentSession = options.configuration.parentSessionId ? this._sessions.get(options.configuration.parentSessionId) : undefined;
         const contrib = this.sessionContributionRegistry.get(options.configuration.type);
         const sessionFactory = contrib ? contrib.debugSessionFactory() : this.debugSessionFactory;
         const session = sessionFactory.get(sessionId, options, parentSession);

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -35,7 +35,7 @@ export interface DebugConfiguration {
      */
     [key: string]: any;
 
-    parentSession?: { id: string };
+    parentSessionId?: string;
 
     lifecycleManagedByParent?: boolean;
 
@@ -80,7 +80,7 @@ export namespace DebugConfiguration {
 
 export interface DebugSessionOptions {
     lifecycleManagedByParent?: boolean;
-    parentSession?: { id: string };
+    parentSessionId?: string;
     consoleMode?: DebugConsoleMode;
     noDebug?: boolean;
     compact?: boolean;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -109,6 +109,7 @@ import { ThemeType } from '@theia/core/lib/common/theme';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { PickOptions, QuickInputButtonHandle } from '@theia/core/lib/common';
 import { Severity } from '@theia/core/lib/common/severity';
+import { DebugConfiguration, DebugSessionOptions } from '@theia/debug/lib/common/debug-configuration';
 
 export interface PreferenceData {
     [scope: number]: any;
@@ -1800,10 +1801,10 @@ export interface DebugExt {
     $resolveDebugConfigurationWithSubstitutedVariablesByHandle(
         handle: number,
         workspaceFolder: string | undefined,
-        debugConfiguration: theia.DebugConfiguration
+        debugConfiguration: DebugConfiguration
     ): Promise<theia.DebugConfiguration | undefined | null>;
 
-    $createDebugSession(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<string>;
+    $createDebugSession(debugConfiguration: DebugConfiguration, workspaceFolder: string | undefined): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;
 }
@@ -1817,7 +1818,7 @@ export interface DebugMain {
     $unregisterDebugConfigurationProvider(handle: number): Promise<void>;
     $addBreakpoints(breakpoints: Breakpoint[]): Promise<void>;
     $removeBreakpoints(breakpoints: string[]): Promise<void>;
-    $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions): Promise<boolean>;
+    $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: DebugSessionOptions): Promise<boolean>;
     $stopDebugging(sessionId?: string): Promise<void>;
     $customRequest(sessionId: string, command: string, args?: any): Promise<DebugProtocol.Response>;
     $getDebugProtocolBreakpoint(sessionId: string, breakpointId: string): Promise<theia.DebugProtocolBreakpoint | undefined>;

--- a/packages/plugin-ext/src/plugin/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/debug/plugin-debug-adapter-session.ts
@@ -24,11 +24,7 @@ import { DebugChannel } from '@theia/debug/lib/common/debug-service';
 /**
  * Server debug adapter session.
  */
-export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
-    readonly type: string;
-    readonly name: string;
-    readonly workspaceFolder: theia.WorkspaceFolder | undefined;
-    readonly configuration: theia.DebugConfiguration;
+export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implements theia.DebugSession {
 
     constructor(
         override readonly debugAdapter: DebugAdapter,
@@ -36,12 +32,24 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
         protected readonly theiaSession: theia.DebugSession) {
 
         super(theiaSession.id, debugAdapter);
-
-        this.type = theiaSession.type;
-        this.name = theiaSession.name;
-        this.workspaceFolder = theiaSession.workspaceFolder;
-        this.configuration = theiaSession.configuration;
     }
+
+    get parentSession(): theia.DebugSession | undefined {
+        return this.theiaSession.parentSession;
+    }
+
+    get type(): string {
+        return this.theiaSession.type;
+    }
+    get name(): string {
+        return this.theiaSession.name;
+    };
+    get workspaceFolder(): theia.WorkspaceFolder | undefined {
+        return this.theiaSession.workspaceFolder;
+    };
+    get configuration(): theia.DebugConfiguration {
+        return this.theiaSession.configuration;
+    };
 
     override async start(channel: DebugChannel): Promise<void> {
         if (this.tracker.onWillStartSession) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10665,6 +10665,12 @@ export module '@theia/plugin' {
         readonly name: string;
 
         /**
+         * The parent session of this debug session, if it was created as a child.
+         * @see DebugSessionOptions.parentSession
+         */
+        readonly parentSession?: DebugSession;
+
+        /**
          * The workspace folder of this session or `undefined` for a folderless setup.
          */
         readonly workspaceFolder: WorkspaceFolder | undefined;


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add suppport vor DebugSession.parentSession. Fixes #11512

Adds support for the parentSession property in theia.d.ts. Includes some minor changes to make sure we're not sending theia.DebugSession object over the wire, but only session ids.

Contributed on behalf of ST Microelectronics

#### How to test
1. Install the vscode extension from here: https://github.com/tsmaeder/castletest (I've attached a pre-built copy to this issue). 
2. Run Theia and open a copy of the theia source code 
3. Run the "Run Browser Backend and Frontend" launch configuration
4. Select various debug sesssions and run the "Show active debug session" command from the command palette.
5. Observe: you should see the name of the correct parent session printed to the output of the Theia instance under test

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
