### PR TITLE
Add support for TaskGroup.id and isDefault. 

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1444,6 +1444,7 @@ export interface CommandProperties {
     };
 }
 
+export type TaskGroupKind = 'build' | 'test' | 'rebuild' | 'clean'
 export interface TaskDto {
     type: string;
     taskType?: 'shell' | 'process' | 'customExecution'; // the task execution type
@@ -1454,7 +1455,10 @@ export interface TaskDto {
     // Provide a more specific type when necessary (see ProblemMatcherContribution)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     problemMatcher?: any;
-    group?: string;
+    group?: {
+        kind: TaskGroupKind;
+        isDefault: boolean;
+    }
     detail?: string;
     presentation?: TaskPresentationOptionsDTO;
     runOptions?: RunOptionsDTO;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1444,7 +1444,7 @@ export interface CommandProperties {
     };
 }
 
-export type TaskGroupKind = 'build' | 'test' | 'rebuild' | 'clean'
+export type TaskGroupKind = 'build' | 'test' | 'rebuild' | 'clean';
 export interface TaskDto {
     type: string;
     taskType?: 'shell' | 'process' | 'customExecution'; // the task execution type

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -26,7 +26,7 @@ import { RPCProtocol } from '../../common/rpc-protocol';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common';
 import { TaskProviderRegistry, TaskResolverRegistry, TaskProvider, TaskResolver } from '@theia/task/lib/browser/task-contribution';
 import { interfaces } from '@theia/core/shared/inversify';
-import { TaskInfo, TaskExitedEvent, TaskConfiguration, TaskCustomization, TaskOutputPresentation, RevealKind, PanelKind } from '@theia/task/lib/common/task-protocol';
+import { TaskInfo, TaskExitedEvent, TaskConfiguration, TaskOutputPresentation, RevealKind, PanelKind } from '@theia/task/lib/common/task-protocol';
 import { TaskWatcher } from '@theia/task/lib/common/task-watcher';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TaskDefinitionRegistry } from '@theia/task/lib/browser';
@@ -207,8 +207,11 @@ export class TasksMainImpl implements TasksMain, Disposable {
         if (presentation) {
             partialConfig.presentation = this.convertTaskPresentation(presentation);
         }
-        if (group === 'build' || group === 'test') {
-            partialConfig.group = group;
+        if (group) {
+            partialConfig.group = {
+                kind: group.kind,
+                isDefault: group.isDefault
+            };
         }
         return {
             ...common,
@@ -225,12 +228,13 @@ export class TasksMainImpl implements TasksMain, Disposable {
         if (presentation) {
             partialDto.presentation = this.convertTaskPresentation(presentation);
         }
-        if (group) {
-            if (TaskCustomization.isBuildTask(task)) {
-                partialDto.group = 'build';
-            } else if (TaskCustomization.isTestTask(task)) {
-                partialDto.group = 'test';
-            }
+        if (group === 'build' || group === 'test') {
+            partialDto.group = {
+                kind: group,
+                isDefault: false
+            };
+        } else if (typeof group === 'object') {
+            partialDto.group = group;
         }
         return {
             ...common,

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -185,7 +185,6 @@ describe('Type converters:', () => {
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
-        const groupDto = 'build';
         const group = TaskGroup.Build;
 
         const shellTaskDto: TaskDto = {
@@ -202,7 +201,10 @@ describe('Type converters:', () => {
                 reveal: 3,
                 focus: true
             },
-            group: groupDto,
+            group: {
+                kind: 'build',
+                isDefault: false
+            },
             runOptions: {
                 reevaluateOnRerun: false
             }

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -22,7 +22,6 @@ import * as model from '../common/plugin-api-rpc-model';
 import { MarkdownString } from './markdown-string';
 import { MarkdownString as MarkdownStringInterface } from '@theia/core/lib/common/markdown-rendering';
 import { TaskDto } from '../common/plugin-api-rpc';
-import { TaskGroup } from './types-impl';
 
 describe('Type converters:', () => {
 
@@ -185,7 +184,7 @@ describe('Type converters:', () => {
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
-        const group = TaskGroup.Build;
+        const group = new types.TaskGroup('build', 'Build');
 
         const shellTaskDto: TaskDto = {
             type: shellType,

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -31,8 +31,6 @@ import { MarkdownString as MarkdownStringDTO } from '@theia/core/lib/common/mark
 
 const SIDE_GROUP = -2;
 const ACTIVE_GROUP = -1;
-const BUILD_GROUP = 'build';
-const TEST_GROUP = 'test';
 
 export function toViewColumn(ep?: EditorPosition): theia.ViewColumn | undefined {
     if (typeof ep !== 'number') {
@@ -846,11 +844,11 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
         taskDto.presentation = task.presentationOptions;
     }
 
-    const group = task.group;
-    if (group === types.TaskGroup.Build) {
-        taskDto.group = BUILD_GROUP;
-    } else if (group === types.TaskGroup.Test) {
-        taskDto.group = TEST_GROUP;
+    if (task.group) {
+        taskDto.group = {
+            kind: <rpc.TaskGroupKind>task.group.id,
+            isDefault: !!task.group.isDefault
+        };
     }
 
     const taskDefinition = task.definition;
@@ -936,11 +934,11 @@ export function toTask(taskDto: TaskDto): theia.Task {
     }
 
     if (group) {
-        if (group === BUILD_GROUP) {
-            result.group = types.TaskGroup.Build;
-        } else if (group === TEST_GROUP) {
-            result.group = types.TaskGroup.Test;
-        }
+        result.group = new types.TaskGroup(
+            group.kind,
+            group.kind,
+            group.isDefault
+        );
     }
 
     if (presentation) {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2008,7 +2008,6 @@ export class CustomExecution {
 
 @es5ClassCompat
 export class TaskGroup {
-    private groupId: string;
 
     public static Clean: TaskGroup = new TaskGroup('clean', 'Clean');
     public static Build: TaskGroup = new TaskGroup('build', 'Build');
@@ -2030,19 +2029,13 @@ export class TaskGroup {
         }
     }
 
-    constructor(id: string, label: string) {
-        if (typeof id !== 'string') {
-            throw illegalArgument('id');
-        }
-        if (typeof label !== 'string') {
-            throw illegalArgument('name');
-        }
-        this.groupId = id;
+    constructor(id: 'clean' | 'build' | 'rebuild' | 'test', label: string);
+    constructor(id: 'clean' | 'build' | 'rebuild' | 'test', label: string, isDefault?: boolean | undefined);
+    constructor(readonly id: 'clean' | 'build' | 'rebuild' | 'test', label: string, isDefault?: boolean | undefined) {
+        this.isDefault = !!isDefault;
     }
 
-    get id(): string {
-        return this.groupId;
-    }
+    readonly isDefault: boolean;
 }
 
 export enum TaskScope {
@@ -2127,6 +2120,7 @@ export class Task {
         }
         this.isTaskBackground = false;
         this.presentationOptions = Object.create(null);
+        this.taskRunOptions = Object.create(null);
     }
 
     get definition(): theia.TaskDefinition {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -11513,6 +11513,17 @@ export module '@theia/plugin' {
         /** The test all task group */
         static Test: TaskGroup;
 
+        /**
+         * Whether the task that is part of this group is the default for the group.
+         * This property cannot be set through API, and is controlled by a user's task configurations.
+         */
+        readonly isDefault: boolean | undefined;
+
+        /**
+         * The ID of the task group. Is one of TaskGroup.Clean.id, TaskGroup.Build.id, TaskGroup.Rebuild.id, or TaskGroup.Test.id.
+         */
+        readonly id: string;
+
         private constructor(id: string, label: string);
     }
 

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -115,7 +115,7 @@ export namespace TaskOutputPresentation {
 
 export interface TaskCustomization {
     type: string;
-    group?: 'build' | 'test' | 'none' | { kind: 'build' | 'test', isDefault: true };
+    group?: 'build' | 'test' | 'rebuild' | 'clean' | 'none' | { kind: 'build' | 'test' | 'rebuild' | 'clean', isDefault: boolean };
     problemMatcher?: string | ProblemMatcherContribution | (string | ProblemMatcherContribution)[];
     presentation?: TaskOutputPresentation;
     detail?: string;
@@ -136,19 +136,23 @@ export interface TaskCustomization {
 }
 export namespace TaskCustomization {
     export function isBuildTask(task: TaskCustomization): boolean {
-        return task.group === 'build' || !!task.group && typeof task.group === 'object' && task.group.kind === 'build';
+        return task.group === 'build' || typeof task.group === 'object' && task.group.kind === 'build';
     }
 
     export function isDefaultBuildTask(task: TaskCustomization): boolean {
-        return !!task.group && typeof task.group === 'object' && task.group.kind === 'build' && task.group.isDefault;
+        return isDefaultTask(task) && isBuildTask(task);
+    }
+
+    export function isDefaultTask(task: TaskCustomization): boolean {
+        return typeof task.group === 'object' && task.group.isDefault;
     }
 
     export function isTestTask(task: TaskCustomization): boolean {
-        return task.group === 'test' || !!task.group && typeof task.group === 'object' && task.group.kind === 'test';
+        return task.group === 'test' || typeof task.group === 'object' && task.group.kind === 'test';
     }
 
     export function isDefaultTestTask(task: TaskCustomization): boolean {
-        return !!task.group && typeof task.group === 'object' && task.group.kind === 'test' && task.group.isDefault;
+        return isDefaultTask(task) && isTestTask(task);
     }
 }
 


### PR DESCRIPTION
#### What it does

Adds support for id and isDefault and includes a small drive-by fix in the Task implementation where the taskRunOptions object was not properly initialized.

Fixes #11519

Contributed on behalf of ST Microelectronics


#### How to test
1. Install the attached vscode extension. It is built from https://github.com/tsmaeder/castletest
2. Open a workspace that generates some tasks. I use the source of Theia
3. Configure some tasks, playing with the "id" and "default" fields
4. Inspect the task by invoking "Dump task info to console" from the command palette and make sure the right values are shown for "isDefault" and "id".

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
