### PR TITLE
Add Comment#timestamp

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -660,6 +660,8 @@ export interface Comment {
     readonly contextValue?: string;
     readonly label?: string;
     readonly mode?: CommentMode;
+    /** Timestamp serialized as ISO date string via Date.prototype.toISOString */
+    readonly timestamp?: string;
 }
 
 export enum CommentThreadCollapsibleState {

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -479,6 +479,7 @@ export class ReviewComment<P extends ReviewComment.Props = ReviewComment.Props> 
             <div className={'review-comment-contents'}>
                 <div className={'comment-title monaco-mouse-cursor-text'}>
                     <strong className={'author'}>{comment.userName}</strong>
+                    <small className={'timestamp'}>{this.localeDate(comment.timestamp)}</small>
                     <span className={'isPending'}>{comment.label}</span>
                     <div className={'theia-comments-inline-actions-container'}>
                         <div className={'theia-comments-inline-actions'} role={'toolbar'}>
@@ -497,6 +498,16 @@ export class ReviewComment<P extends ReviewComment.Props = ReviewComment.Props> 
                     commands={commands} />
             </div>
         </div>;
+    }
+    protected localeDate(timestamp: string | undefined): string {
+        if (timestamp === undefined) {
+            return '';
+        }
+        const date = new Date(timestamp);
+        if (!isNaN(date.getTime())) {
+            return date.toLocaleString();
+        }
+        return '';
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/style/comments.css
+++ b/packages/plugin-ext/src/main/browser/style/comments.css
@@ -149,6 +149,12 @@
     line-height: var(--theia-content-line-height);
 }
 
+.monaco-editor .review-widget .body .review-comment .review-comment-contents .timestamp {
+    line-height: var(--theia-content-line-height);
+    margin: 0 5px 0 5px;
+    padding: 0 2px 0 2px;
+}
+
 .monaco-editor .review-widget .body .review-comment .review-comment-contents .isPending {
     margin: 0 5px 0 5px;
     padding: 0 2px 0 2px;

--- a/packages/plugin-ext/src/plugin/comments.ts
+++ b/packages/plugin-ext/src/plugin/comments.ts
@@ -491,6 +491,7 @@ function convertToModeComment(thread: ExtHostCommentThread, commentController: C
     }
 
     const iconPath = theiaComment.author && theiaComment.author.iconPath ? theiaComment.author.iconPath.toString() : undefined;
+    const date = theiaComment.timestamp ? theiaComment.timestamp.toISOString() : undefined;
 
     return {
         mode: theiaComment.mode,
@@ -500,6 +501,7 @@ function convertToModeComment(thread: ExtHostCommentThread, commentController: C
         userName: theiaComment.author.name,
         userIconPath: iconPath,
         label: theiaComment.label,
+        timestamp: date,
     };
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12084,6 +12084,11 @@ export module '@theia/plugin' {
          * Label will be rendered next to authorName if exists.
          */
         label?: string;
+
+        /**
+         * Optional timestamp.
+         */
+        timestamp?: Date;
     }
 
     /**


### PR DESCRIPTION
#### What it does

_Add Comment#timestamp optional property_
This adds the timeStamp optional property from Comment to improve vscode api coverage. It also displays the timestamp of each comments in the Comment Thread widget

Fixes #11702 

Contributed on behalf of ST Microelectronics

#### How to test 
Note: there are currently some issues with menus, since theia 1.28.0. This is due to #11290, integrated in 1.28.0. Prior to this change, the comment sample works on theia 1.27.0. So to test this change, I cherry-picked my commit on top of 1.27.0 tag. Please see also #11730 for this menu issues.
1. Install forked extension [#comment-sample-0.0.1](https://github.com/rschnekenbu/vscode-extension-samples/releases/tag/0.0.1) vsix file
2. Create a comment using the side bar while comparing 2 test files. 
![addCommentTimeStamp](https://user-images.githubusercontent.com/3964263/205917926-9c606ad0-5d9f-40ee-8c6b-7c56a266525a.gif)

4. The timestamp should be displayed along the user name.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
