### PR TITLE
[vscode] Add `WebviewOptions.enableForms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.33.0 - unreleased
 
 - [scripts] integrated start-up performance scripts into nightly master build [#10463](https://github.com/eclipse-theia/theia/pull/10463) - Contributed on behalf of STMicroelectronics
+- [plugin] added `enableForms` field to `WebviewOptions` [#11983](https://github.com/eclipse-theia/theia/pull/11983) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.33.0">[Breaking Changes:](#breaking_changes_1.33.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -223,11 +223,12 @@ export class CustomEditorsMainImpl implements CustomEditorsMain, Disposable {
         const view = await this.widgetManager.getOrCreateWidget<CustomEditorWidget>(CustomEditorWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
         this.webviewsMain.hookWebview(view);
         view.title.label = title;
-        const { enableFindWidget, retainContextWhenHidden, enableScripts, localResourceRoots, ...contentOptions } = options;
+        const { enableFindWidget, retainContextWhenHidden, enableScripts, enableForms, localResourceRoots, ...contentOptions } = options;
         view.viewColumn = ViewColumn.One; // behaviour might be overridden later using widgetOpenerOptions (if available)
         view.options = { enableFindWidget, retainContextWhenHidden };
         view.setContentOptions({
             allowScripts: enableScripts,
+            allowForms: enableForms,
             localResourceRoots: localResourceRoots && localResourceRoots.map(root => root.toString()),
             ...contentOptions,
             ...view.contentOptions

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -479,7 +479,14 @@
                 const newFrame = document.createElement('iframe');
                 newFrame.setAttribute('id', 'pending-frame');
                 newFrame.setAttribute('frameborder', '0');
-                newFrame.setAttribute('sandbox', options.allowScripts ? 'allow-scripts allow-forms allow-same-origin allow-downloads' : 'allow-same-origin');
+                const sandboxOptions = ['allow-same-origin'];
+                if (options.allowScripts) {
+                    sandboxOptions.push('allow-scripts', 'allow-downloads');
+                }
+                if (options.allowForms || (options.allowScripts && options.allowForms === undefined)) {
+                    sandboxOptions.push('allow-forms');
+                }
+                newFrame.setAttribute('sandbox', sandboxOptions.join(' '));
                 if (host.fakeLoad) {
                     // We should just be able to use srcdoc, but I wasn't
                     // seeing the service worker applying properly.

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -483,7 +483,7 @@
                 if (options.allowScripts) {
                     sandboxOptions.push('allow-scripts', 'allow-downloads');
                 }
-                if (options.allowForms || (options.allowScripts && options.allowForms === undefined)) {
+                if (options.allowForms ?? options.allowScripts) {
                     sandboxOptions.push('allow-forms');
                 }
                 newFrame.setAttribute('sandbox', sandboxOptions.join(' '));

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -73,6 +73,7 @@ export const enum WebviewMessageChannels {
 
 export interface WebviewContentOptions {
     readonly allowScripts?: boolean;
+    readonly allowForms?: boolean;
     readonly localResourceRoots?: ReadonlyArray<string>;
     readonly portMapping?: ReadonlyArray<WebviewPortMapping>;
     readonly enableCommandUris?: boolean;

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -67,10 +67,11 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         this.hookWebview(view);
         view.viewType = viewType;
         view.title.label = title;
-        const { enableFindWidget, retainContextWhenHidden, enableScripts, localResourceRoots, ...contentOptions } = options;
+        const { enableFindWidget, retainContextWhenHidden, enableScripts, enableForms, localResourceRoots, ...contentOptions } = options;
         view.options = { enableFindWidget, retainContextWhenHidden };
         view.setContentOptions({
             allowScripts: enableScripts,
+            allowForms: enableForms,
             localResourceRoots: localResourceRoots && localResourceRoots.map(root => root.toString()),
             ...contentOptions
         });
@@ -171,9 +172,10 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
 
     async $setOptions(handle: string, options: WebviewOptions): Promise<void> {
         const webview = await this.getWebview(handle);
-        const { enableScripts, localResourceRoots, ...contentOptions } = options;
+        const { enableScripts, enableForms, localResourceRoots, ...contentOptions } = options;
         webview.setContentOptions({
             allowScripts: enableScripts,
+            allowForms: enableForms,
             localResourceRoots: localResourceRoots && localResourceRoots.map(root => root.toString()),
             ...contentOptions
         });
@@ -210,10 +212,11 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         }
 
         const options = widget.options;
-        const { allowScripts, localResourceRoots, ...contentOptions } = widget.contentOptions;
+        const { allowScripts, allowForms, localResourceRoots, ...contentOptions } = widget.contentOptions;
         this.updateViewState(widget);
         await this.proxy.$deserializeWebviewPanel(handle, widget.viewType, title, state, widget.viewState, {
             enableScripts: allowScripts,
+            enableForms: allowForms,
             localResourceRoots: localResourceRoots && localResourceRoots.map(root => URI.parse(root)),
             ...contentOptions,
             ...options

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3769,6 +3769,14 @@ export module '@theia/plugin' {
         readonly enableScripts?: boolean;
 
         /**
+         * Controls whether forms are enabled in the webview content or not.
+         *
+         * Defaults to true if {@link WebviewOptions.enableScripts scripts are enabled}. Otherwise defaults to false.
+         * Explicitly setting this property to either true or false overrides the default.
+         */
+        readonly enableForms?: boolean;
+
+        /**
          * Controls whether command uris are enabled in webview content or not.
          *
          * Defaults to false.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Added the optional `enableForms` field to `WebviewOptions`. 
This allows the `allow-forms` sandbox attribute to be set.

Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
To test you can use the following VSCode extension:

[webview-forms-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10206925/webview-forms-0.0.1.zip)

It contributes 6 commands (category: `Test enableForms`) that will create a webview with different options set (You can see the options set in the command name and the webview will display them as well).
When you opened the webview you can inspect the DevTools to see that the `allow-forms` sandbox attribute is correctly set (or not set).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
