### PR TITLE
Add iconPath and stub color optional properties to TerminalOptions and ExtensionTerminalOptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.34.0 - 01/26/2023
+
+- [plugin] added support for `isTransient` of `TerminalOptions` and `ExternalTerminalOptions` VS Code API [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
+- [terminal] added support for preference `terminal.integrated.enablePersistentSessions` to allow disabling restoring terminals on reload [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
+
 ## v1.33.0 - 12/20/2022
 
 - [application-package] added support for declaring extensions as peer dependencies [#11808](https://github.com/eclipse-theia/theia/pull/11808)

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -27,6 +27,7 @@ import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/c
 import { ShellTerminalServerProxy } from '@theia/terminal/lib/common/shell-terminal-protocol';
 import { TerminalLink, TerminalLinkProvider } from '@theia/terminal/lib/browser/terminal-link-provider';
 import { URI } from '@theia/core/lib/common/uri';
+import { getIconClass } from '../../plugin/terminal-ext';
 
 /**
  * Plugin api service allows working with terminal emulator.
@@ -127,6 +128,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
             const terminal = await this.terminals.newTerminal({
                 id,
                 title: options.name,
+                iconClass: getIconClass(options),
                 shellPath: options.shellPath,
                 shellArgs: options.shellArgs,
                 cwd: options.cwd ? new URI(options.cwd) : undefined,

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -137,7 +137,8 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
                 attributes: options.attributes,
                 hideFromUser: options.hideFromUser,
                 location: this.getTerminalLocation(options, parentId),
-                isPseudoTerminal
+                isPseudoTerminal,
+                isTransient: options.isTransient
             });
             if (options.message) {
                 terminal.writeLine(options.message);

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -20,9 +20,25 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import * as theia from '@theia/plugin';
-import { Disposable, EnvironmentVariableMutatorType } from './types-impl';
+import { Disposable, EnvironmentVariableMutatorType, ThemeIcon } from './types-impl';
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { ProvidedTerminalLink } from '../common/plugin-api-rpc-model';
+import { ThemeIcon as MonacoThemeIcon } from '@theia/monaco-editor-core/esm/vs/platform/theme/common/themeService';
+
+export function getIconUris(iconPath: theia.TerminalOptions['iconPath']): { id: string } | undefined {
+    if (ThemeIcon.is(iconPath)) {
+        return { id: iconPath.id };
+    }
+    return undefined;
+}
+
+export function getIconClass(options: theia.TerminalOptions): string | undefined {
+    const iconClass = getIconUris(options.iconPath);
+    if (iconClass) {
+        return MonacoThemeIcon.asClassName(iconClass);
+    }
+    return undefined;
+}
 
 /**
  * Provides high level terminal plugin api to use in the Theia plugins.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3016,6 +3016,19 @@ export module '@theia/plugin' {
          * Terminal attributes. Can be useful to apply some implementation specific information.
          */
         attributes?: { [key: string]: string | null };
+
+        /**
+         * The icon path or {@link ThemeIcon} for the terminal.
+         */
+        iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+
+        /**
+         * The icon {@link ThemeColor} for the terminal.
+         * The `terminal.ansi*` theme keys are
+         * recommended for the best contrast and consistency across themes.
+         * @stubbed
+         */
+        color?: ThemeColor;
     }
 
     /**
@@ -3089,6 +3102,18 @@ export module '@theia/plugin' {
          * This will only take effect when `terminal.integrated.enablePersistentSessions` is enabled.
          */
         isTransient?: boolean;
+
+        /**
+         * The icon path or {@link ThemeIcon} for the terminal.
+         */
+        iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+
+        /**
+         * The icon {@link ThemeColor} for the terminal.
+         * The standard `terminal.ansi*` theme keys are
+         * recommended for the best contrast and consistency across themes.
+         */
+        color?: ThemeColor;
     }
 
     /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3007,6 +3007,12 @@ export module '@theia/plugin' {
         location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
 
         /**
+         * Opt-out of the default terminal persistence on restart and reload.
+         * This will only take effect when `terminal.integrated.enablePersistentSessions` is enabled.
+         */
+        isTransient?: boolean;
+
+        /**
          * Terminal attributes. Can be useful to apply some implementation specific information.
          */
         attributes?: { [key: string]: string | null };
@@ -3077,6 +3083,12 @@ export module '@theia/plugin' {
          * The {@link TerminalLocation} or {@link TerminalEditorLocationOptions} or {@link TerminalSplitLocationOptions} for the terminal.
          */
         location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
+
+        /**
+         * Opt-out of the default terminal persistence on restart and reload.
+         * This will only take effect when `terminal.integrated.enablePersistentSessions` is enabled.
+         */
+        isTransient?: boolean;
     }
 
     /**

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -168,6 +168,11 @@ export interface TerminalWidgetOptions {
     readonly title?: string;
 
     /**
+     * icon class
+     */
+    readonly iconClass?: string;
+
+    /**
      * Path to the executable shell. For example: `/bin/bash`, `bash`, `sh`.
      */
     readonly shellPath?: string;

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -231,4 +231,9 @@ export interface TerminalWidgetOptions {
     readonly hideFromUser?: boolean;
 
     readonly location?: TerminalLocationOptions;
+
+    /**
+     * When enabled, the terminal will not be persisted across window reloads.
+     */
+    readonly isTransient?: boolean;
 }

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -153,6 +153,11 @@ export const TerminalConfigSchema: PreferenceSchema = {
                 nls.localize('theia/terminal/confirmCloseChildren', 'Confirm if there are any terminals that have child processes.'),
             ],
             default: 'never'
+        },
+        'terminal.integrated.enablePersistentSessions': {
+            type: 'boolean',
+            description: nls.localizeByDefault('Persist terminal sessions for the workspace across window reloads.'),
+            default: true
         }
     }
 };
@@ -181,7 +186,8 @@ export interface TerminalConfiguration {
     'terminal.integrated.shellArgs.windows': string[],
     'terminal.integrated.shellArgs.osx': string[],
     'terminal.integrated.shellArgs.linux': string[],
-    'terminal.integrated.confirmOnExit': ConfirmOnExitType
+    'terminal.integrated.confirmOnExit': ConfirmOnExitType,
+    'terminal.integrated.enablePersistentSessions': boolean
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -117,7 +117,12 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @postConstruct()
     protected init(): void {
         this.setTitle(this.options.title || TerminalWidgetImpl.LABEL);
-        this.title.iconClass = codicon('terminal');
+
+        if (this.options.iconClass) {
+            this.title.iconClass = this.options.iconClass;
+        } else {
+            this.title.iconClass = codicon('terminal');
+        }
 
         if (this.options.kind) {
             this.terminalKind = this.options.kind;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -407,6 +407,11 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         return this.options.hideFromUser ?? false;
     }
 
+    get transient(): boolean {
+        // The terminal is transient if session persistence is disabled or it's explicitly marked as transient
+        return !this.preferences['terminal.integrated.enablePersistentSessions'] || !!this.options.isTransient;
+    }
+
     onDispose(onDispose: () => void): void {
         this.toDispose.push(Disposable.create(onDispose));
     }
@@ -421,15 +426,15 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     storeState(): object {
         this.closeOnDispose = false;
-        if (this.options.isPseudoTerminal) {
+        if (this.transient || this.options.isPseudoTerminal) {
             return {};
         }
         return { terminalId: this.terminalId, titleLabel: this.title.label };
     }
 
     restoreState(oldState: object): void {
-        // pseudo terminal can not restore
-        if (this.options.isPseudoTerminal) {
+        // transient terminals and pseudo terminals are not restored
+        if (this.transient || this.options.isPseudoTerminal) {
             this.dispose();
             return;
         }


### PR DESCRIPTION
#### What it does

_Add iconPath optional property_ to TerminalOptions and ExtensionTerminalOptions
_Stub color optional property_ to TerminalOptions and ExtensionTerminalOptions
This allows creation of terminals from extension with different icons.

Fixes #11504

Only commit da5f0ce is relevant in this review, the other one from lucas is only a commit missing on our fork. 

Contributed on behalf of STMicroelectronics

#### How to test 
1. Install extension [terminal-creation-options-0.0.13.zip](https://github.com/eclipsesource/theia/files/10393229/terminal-creation-options-0.0.13.zip). This extension provides several actions to open a new terminal with a different icon in the title and several color options (not supported yet)
2. Trigger in the command Palette different commands:
* 'Create terminal with green Theme Icon'. a new terminal with a file icon shall open.
* 'Create  terminal with red URI Icon'. A terminal with default terminal icon shall open as the URIs iconPath is not yet supported.
* 'Create new terminal' should create a terminal with standard terminal icon. 

![terminal-colorandicon](https://user-images.githubusercontent.com/3964263/211833834-46e47e67-550b-44b5-b1af-e9f72e27f864.gif)

#### Known limitations
1. Color is not supported but stubbed, so the extension is still supported. The support is strange in vscode, as having a specific color changes also the icon to a kind of cube (at least when I am testing). The main technical reason is that underlying representation Title<Widget>, coming from phosphorjs library, does not directly support styling. The phosphorjs library is deprecated now, so this may be hard to have a proper fix. 
2. Only ThemeIcon is supported currently in iconPath. URI(s) based icons are not supported, but still do not fail. Same reason for the color management applies here, the limitation comes from Title<Widget> only accepting iconClass string. I have seen some similar work on webview title, but this includes some dependencies to classes in plugin-ext package (PluginSharedStyle, and some other elements). In Terminal-Widget-impl, we are in terminal package, which can not depend on plugin-ext as it would introduce circular dependencies. So there maybe some other way to implement, but with either some code duplication or a larger refactoring required. This will be part of a following issue.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
