### PR TITLE
Fix 'pickString' evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [plugin] added support for `isTransient` of `TerminalOptions` and `ExternalTerminalOptions` VS Code API [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
 - [terminal] added support for preference `terminal.integrated.enablePersistentSessions` to allow disabling restoring terminals on reload [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
+- [variable-resolver] fixed evaluations of `pickString` variables [#12100](https://github.com/eclipse-theia/theia/pull/12100) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.34.0">[Breaking Changes:](#breaking_changes_1.34.0)</a>
 

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -135,7 +135,8 @@ export class CommonVariableContribution implements VariableContribution {
                             });
                         }
                     }
-                    return this.quickInputService?.showQuickPick(elements, { placeholder: input.description });
+                    const selectedPick = await this.quickInputService?.showQuickPick(elements, { placeholder: input.description });
+                    return selectedPick?.value;
                 }
                 if (input.type === 'command') {
                     if (typeof input.command !== 'string') {


### PR DESCRIPTION
Fixes the 'pickString' evaluation in tasks and launch configurations.

Fixes #11585

Contributed on behalf of STMicroelectronics

#### What it does
Similar to 'promptString', 'pickString' can be used to replace variables in task and launch configurations. However 'pickString' values were not correctly handled which prevented them from being evaluated. This is now fixed.

#### How to test

Run the task from the following `task.json`

```
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "echo select foo or bar",
            "type": "shell",
            "command": "echo ${input:select-foo-or-bar}",
            "problemMatcher": []
        }
    ],
    "inputs": [
        {
            "id": "select-foo-or-bar",
            "type": "pickString",
            "description": "Select foo or bar",
            "default": "foo",
            "options": [
                "foo",
                "bar"
            ],
        }
    ]
}
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
