### PR TITLE
[vscode] Support TerminalExitReason

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -157,6 +157,7 @@ import {
     InputBoxValidationSeverity,
     TerminalLink,
     TerminalLocation,
+    TerminalExitReason,
     TerminalProfile,
     InlayHint,
     InlayHintKind,
@@ -1301,7 +1302,8 @@ export function createAPIFactory(
             TabInputNotebookDiff: NotebookDiffEditorTabInput,
             TabInputWebview: WebviewEditorTabInput,
             TabInputTerminal: TerminalEditorTabInput,
-            TerminalLocation
+            TerminalLocation,
+            TerminalExitReason
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -20,7 +20,7 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import * as theia from '@theia/plugin';
-import { Disposable, EnvironmentVariableMutatorType, ThemeIcon } from './types-impl';
+import { Disposable, EnvironmentVariableMutatorType, TerminalExitReason, ThemeIcon } from './types-impl';
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { ProvidedTerminalLink } from '../common/plugin-api-rpc-model';
 import { ThemeIcon as MonacoThemeIcon } from '@theia/monaco-editor-core/esm/vs/platform/theme/common/themeService';
@@ -198,7 +198,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     $terminalClosed(id: string, exitStatus: theia.TerminalExitStatus | undefined): void {
         const terminal = this._terminals.get(id);
         if (terminal) {
-            terminal.exitStatus = exitStatus ?? { code: undefined };
+            terminal.exitStatus = exitStatus ?? { code: undefined, reason: TerminalExitReason.Unknown };
             this.onDidCloseTerminalEmitter.fire(terminal);
             this._terminals.delete(id);
         }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2043,6 +2043,14 @@ export class TerminalProfile {
     }
 }
 
+export enum TerminalExitReason {
+    Unknown = 0,
+    Shutdown = 1,
+    Process = 2,
+    User = 3,
+    Extension = 4,
+}
+
 @es5ClassCompat
 export class FileDecoration {
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3058,6 +3058,41 @@ export module '@theia/plugin' {
          *   without providing an exit code.
          */
         readonly code: number | undefined;
+
+        /**
+         * The reason that triggered the exit of a terminal.
+         */
+        readonly reason: TerminalExitReason;
+    }
+
+    /**
+     * Terminal exit reason kind.
+     */
+    export enum TerminalExitReason {
+        /**
+         * Unknown reason.
+         */
+        Unknown = 0,
+
+        /**
+         * The window closed/reloaded.
+         */
+        Shutdown = 1,
+
+        /**
+         * The shell process exited.
+         */
+        Process = 2,
+
+        /**
+         * The user closed the terminal.
+         */
+        User = 3,
+
+        /**
+         * An extension disposed the terminal.
+         */
+        Extension = 4
     }
 
     /**

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -18,7 +18,7 @@ import { Event, ViewColumn } from '@theia/core';
 import { BaseWidget } from '@theia/core/lib/browser';
 import { CommandLineOptions } from '@theia/process/lib/common/shell-command-builder';
 import { TerminalSearchWidget } from '../search/terminal-search-widget';
-import { TerminalProcessInfo } from '../../common/base-terminal-protocol';
+import { TerminalProcessInfo, TerminalExitReason } from '../../common/base-terminal-protocol';
 import URI from '@theia/core/lib/common/uri';
 
 export interface TerminalDimensions {
@@ -28,6 +28,7 @@ export interface TerminalDimensions {
 
 export interface TerminalExitStatus {
     readonly code: number | undefined;
+    readonly reason: TerminalExitReason;
 }
 
 export type TerminalLocationOptions = TerminalLocation | TerminalEditorLocation | TerminalSplitLocation;

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -63,9 +63,18 @@ export namespace IBaseTerminalServer {
 export interface IBaseTerminalExitEvent {
     terminalId: number;
 
-    // Exactly one of code and signal will be set.
+    // Either code and reason will be set or signal.
     code?: number;
+    reason?: TerminalExitReason;
     signal?: string;
+}
+
+export enum TerminalExitReason {
+    Unknown = 0,
+    Shutdown = 1,
+    Process = 2,
+    User = 3,
+    Extension = 4,
 }
 
 export interface IBaseTerminalErrorEvent {

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -28,7 +28,8 @@ import {
     ExtensionOwnedEnvironmentVariableMutator,
     EnvironmentVariableMutatorType,
     EnvironmentVariableCollectionWithPersistence,
-    SerializableExtensionEnvironmentVariableCollection
+    SerializableExtensionEnvironmentVariableCollection,
+    TerminalExitReason
 } from '../common/base-terminal-protocol';
 import { TerminalProcess, ProcessManager, TaskTerminalProcess } from '@theia/process/lib/node';
 import { ShellProcess } from './shell-process';
@@ -160,6 +161,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
                 this.client.onTerminalExitChanged({
                     'terminalId': term.id,
                     'code': event.code,
+                    'reason': TerminalExitReason.Process,
                     'signal': event.signal
                 });
             }


### PR DESCRIPTION
#### What it does

Adds support for terminal exit status reason and TerminalExitReason enum 

Fixes [#12023](https://github.com/eclipse-theia/theia/issues/12023)

contributed on behalf of ST Microelectronics

#### How to test
This PR adds a reason why the terminal view was closed. This may come from a user action (close buttton), from the process itself that was exited, from an extension or from tool shutdown. 
Here is an extension based on vscode example with additional information on terminal window close event 

[vscode-terminal-api-example-0.0.1.zip](https://github.com/eclipsesource/theia/files/10795468/vscode-terminal-api-example-0.0.1.zip)

1. Testing close on user action
- open _Command Palette..._ 
- select _Terminal API: Create Terminal_ 
- select _Terminal API: Show Terminal_ and select one terminal
- simply close terminal with 'X' button
- notification shall indicate 3 as exit reason (**User** value)

2. Testing close on process exit
- open _Command Palette..._ 
- select _Terminal API: Create Terminal_ 
- select _Terminal API: Show Terminal_ and select one terminal
- type _'exit'_ in the terminal window
- notification shall indicate 2 as exit reason (**Process** value)

3. Testing close by extension
- open _Command Palette..._ 
- select _Terminal API: Create Terminal_ 
- select _Terminal API: Show Terminal_ and select one terminal
- select _Terminal API: Dispose_ and select one terminal
- notification shall indicate 4 as exit reason (**Extension** value)

I could not find a way to reproduce and to check shutdown reason.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
