### PR TITLE
Add boolean suppression DebugSessionOptions

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -210,7 +210,8 @@ export class DebugSessionManager {
     protected async startConfiguration(options: DebugConfigurationSessionOptions): Promise<DebugSession | undefined> {
         return this.progressService.withProgress('Start...', 'debug', async () => {
             try {
-                if (!await this.saveAll()) {
+                // If a parent session is available saving should be handled by the parent
+                if (!options.configuration.parentSessionId && !options.configuration.suppressSaveBeforeStart && !await this.saveAll()) {
                     return undefined;
                 }
                 await this.fireWillStartDebugSession();

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -72,6 +72,21 @@ export interface DebugConfiguration {
 
     /** Task to run after debug session ends */
     postDebugTask?: string | TaskIdentifier;
+
+    /**
+     * When true, a save will not be triggered for open editors when starting a debug session,
+     * regardless of the value of the `debug.saveBeforeStart` setting.
+     */
+    suppressSaveBeforeStart?: boolean;
+
+    /** When true, the debug toolbar will not be shown for this session. */
+    suppressDebugToolbar?: boolean;
+
+    /** When true, the window statusbar color will not be changed for this session. */
+    suppressDebugStatusbar?: boolean;
+
+    /** When true, the debug viewlet will not be automatically revealed for this session. */
+    suppressDebugView?: boolean;
 }
 export namespace DebugConfiguration {
     export function is(arg: unknown): arg is DebugConfiguration {
@@ -85,6 +100,10 @@ export interface DebugSessionOptions {
     consoleMode?: DebugConsoleMode;
     noDebug?: boolean;
     compact?: boolean;
+    suppressSaveBeforeStart?: boolean;
+    suppressDebugToolbar?: boolean;
+    suppressDebugStatusbar?: boolean;
+    suppressDebugView?: boolean;
 }
 
 export enum DebugConsoleMode {

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -79,9 +79,6 @@ export interface DebugConfiguration {
      */
     suppressSaveBeforeStart?: boolean;
 
-    /** When true, the debug toolbar will not be shown for this session. */
-    suppressDebugToolbar?: boolean;
-
     /** When true, the window statusbar color will not be changed for this session. */
     suppressDebugStatusbar?: boolean;
 
@@ -101,7 +98,6 @@ export interface DebugSessionOptions {
     noDebug?: boolean;
     compact?: boolean;
     suppressSaveBeforeStart?: boolean;
-    suppressDebugToolbar?: boolean;
     suppressDebugStatusbar?: boolean;
     suppressDebugView?: boolean;
 }

--- a/packages/plugin-ext/src/plugin/debug/debug-ext.ts
+++ b/packages/plugin-ext/src/plugin/debug/debug-ext.ts
@@ -181,6 +181,10 @@ export class DebugExtImpl implements DebugExt {
             parentSessionId: options.parentSession?.id,
             compact: options.compact,
             consoleMode: options.consoleMode,
+            suppressSaveBeforeStart: options.suppressSaveBeforeStart,
+            suppressDebugToolbar: options.suppressDebugToolbar,
+            suppressDebugStatusbar: options.suppressDebugStatusbar,
+            suppressDebugView: options.suppressDebugView,
             lifecycleManagedByParent: options.lifecycleManagedByParent,
             noDebug: options.noDebug
         });

--- a/packages/plugin-ext/src/plugin/debug/debug-ext.ts
+++ b/packages/plugin-ext/src/plugin/debug/debug-ext.ts
@@ -182,7 +182,6 @@ export class DebugExtImpl implements DebugExt {
             compact: options.compact,
             consoleMode: options.consoleMode,
             suppressSaveBeforeStart: options.suppressSaveBeforeStart,
-            suppressDebugToolbar: options.suppressDebugToolbar,
             suppressDebugStatusbar: options.suppressDebugStatusbar,
             suppressDebugView: options.suppressDebugView,
             lifecycleManagedByParent: options.lifecycleManagedByParent,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -11539,6 +11539,27 @@ export module '@theia/plugin' {
          * If compact is true, debug sessions with a single child are hidden in the CALL STACK view to make the tree more compact.
          */
         compact?: boolean;
+
+        /**
+         * When true, a save will not be triggered for open editors when starting a debug session,
+         * regardless of the value of the `debug.saveBeforeStart` setting.
+         */
+        suppressSaveBeforeStart?: boolean;
+
+        /**
+         * When true, the debug toolbar will not be shown for this session.
+         */
+        suppressDebugToolbar?: boolean;
+
+        /**
+         * When true, the window statusbar color will not be changed for this session.
+         */
+        suppressDebugStatusbar?: boolean;
+
+        /**
+         * When true, the debug viewlet will not be automatically revealed for this session.
+         */
+        suppressDebugView?: boolean;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add options to suppress the debugging statusbar, toolbar and view. 
As well as the saving before starting a debugging session.

Contributed on behalf of STMicroelectronics

_Note:_
Parent/child sessions are currently handled as followed:
- For the saving supression only the root session is taken into account as this could have unintended side effects (saving files when not wanted), if a child session specifies something else than the parent session.
- For the other three supressions (debug view, toolbar and statusbar) the value of the current session is evaluated. If there is no value the nearest parent session will be evaluated.

I mostly went with two different approaches here due to the significance of the actions (saving vs graphical-only), but your input is welcome and i will gladly unify the approaches, when the "better" solution is identified.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Install this extension: [helloworld-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10811670/helloworld-sample-0.0.1.zip)
It registers a few commands that start the "Launch Browser Backend" debug config with different options set.
- Open theia and the theia repository as the workspace.
- Add the following to your setting.json file:

>   "debug.saveBeforeStart": "allEditorsInActiveGroup",
>   "debug.openDebug": "openOnSessionStart",
>   "files.autoSave": "off",

- Trigger one of the `Start Debugging` commands. It says in parenthesis which options are enabled.
- See if the behavior is correct:

> suppressDebugStatusbar?: boolean
> When true, the window statusbar color will not be changed for this session.
> 
> suppressDebugToolbar?: boolean
> When true, the debug toolbar will not be shown for this session.
> 
> suppressDebugView?: boolean
> When true, the debug viewlet will not be automatically revealed for this session.
> 
> suppressSaveBeforeStart?: boolean
> When true, a save will not be triggered for open editors when starting a debug session, regardless of the value of the debug.saveBeforeStart setting.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
