### PR TITLE
Fix file watching events being lost

### DIFF
--- a/packages/plugin-ext/src/main/browser/main-file-system-event-service.ts
+++ b/packages/plugin-ext/src/main/browser/main-file-system-event-service.ts
@@ -37,13 +37,13 @@ export class MainFileSystemEventService {
         const proxy = rpc.getProxy(MAIN_RPC_CONTEXT.ExtHostFileSystemEventService);
         const fileService = container.get(FileService);
 
-        // file system events - (changes the editor and other make)
-        const events: FileSystemEvents = {
-            created: [],
-            changed: [],
-            deleted: []
-        };
         this.toDispose.push(fileService.onDidFilesChange(event => {
+            // file system events - (changes the editor and others make)
+            const events: FileSystemEvents = {
+                created: [],
+                changed: [],
+                deleted: []
+            };
             for (const change of event.changes) {
                 switch (change.type) {
                     case FileChangeType.ADDED:
@@ -59,9 +59,6 @@ export class MainFileSystemEventService {
             }
 
             proxy.$onFileEvent(events);
-            events.created.length = 0;
-            events.changed.length = 0;
-            events.deleted.length = 0;
         }));
 
         // BEFORE file operation


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixed an issue with tracking the current `FileSystemEvents` in the `MainFileSystemEventService`.
Before, the events were tracked in a global field which was intended to be cleaned after an `onDidFilesChanges()` update was sent to the proxy.
This is problematic as we do not await sending the update.
Thus, the global field will be cleaned before the update is even sent and therefore, file watching updates might get lost.
This change ensures that a field of events is kept for each update.

Note that simply awaiting the update to be sent is not enough.
This would introduce race conditions as other parallel updates might clean the state of other updates before they are being sent.

Fixes # 12260. (Will remove the whitespace and this on the real PR)

Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install the following extension: [file-watching-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10898166/file-watching-sample-0.0.1.zip)
2. Change/Add/Delete a file
3. All actions should be detected by the extension (should display a console log and a information message in Theia)
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
