### PR TITLE
[vscode] support AuthenticationForceNewSessionOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [workspace] Implement CanonicalUriProvider API #12743 (https://github.com/eclipse-theia/theia/pull/12743 - Contributed on behalf of STMicroelectronics
 - Show command shortcuts in toolbar item tooltips. #12660 (https://github.com/eclipse-theia/theia/pull/12660) - Contributed on behalf of STMicroelectronics
 - [cli] added `check:theia-extensions` which checks the uniqueness of Theia extension versions [#12596](https://github.com/eclipse-theia/theia/pull/12596) - Contributed on behalf of STMicroelectronics
+- [vscode] Support AuthenticationForceNewSessionOptions and detail message [#12752](https://github.com/eclipse-theia/theia/pull/12752) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.40.0">[Breaking Changes:](#breaking_changes_1.40.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/authentication-main.ts
+++ b/packages/plugin-ext/src/main/browser/authentication-main.ts
@@ -34,6 +34,7 @@ import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import * as theia from '@theia/plugin';
 import { QuickPickValue } from '@theia/core/lib/browser/quick-input/quick-input-service';
 import { nls } from '@theia/core/lib/common/nls';
+import { isObject } from '@theia/core';
 
 export function getAuthenticationProviderActivationEvent(id: string): string { return `onAuthenticationRequest:${id}`; }
 
@@ -117,7 +118,7 @@ export class AuthenticationMainImpl implements AuthenticationMain {
         // We may need to prompt because we don't have a valid session modal flows
         if (options.createIfNone || options.forceNewSession) {
             const providerName = this.authenticationService.getLabel(providerId);
-            const detail = (typeof options.forceNewSession === 'object') ? options.forceNewSession!.detail : undefined;
+            const detail = isAuthenticationForceNewSessionOptions(options.forceNewSession) ? options.forceNewSession!.detail : undefined;
             const isAllowed = await this.loginPrompt(providerName, extensionName, !!options.forceNewSession, detail);
             if (!isAllowed) {
                 throw new Error('User did not consent to login.');
@@ -197,10 +198,12 @@ export class AuthenticationMainImpl implements AuthenticationMain {
         return allow;
     }
 
-    protected async loginPrompt(providerName: string, extensionName: string, recreatingSession: boolean, _detail?: string): Promise<boolean> {
-        const message = recreatingSession
+    protected async loginPrompt(providerName: string, extensionName: string, recreatingSession: boolean, detail?: string): Promise<boolean> {
+        let message = recreatingSession
             ? nls.localizeByDefault("The extension '{0}' wants you to sign in again using {1}.", extensionName, providerName)
             : nls.localizeByDefault("The extension '{0}' wants to sign in using {1}.", extensionName, providerName);
+
+        message = detail ? message + ' ' + detail : message;
         const choice = await this.messageService.info(message, 'Allow', 'Cancel');
         return choice === 'Allow';
     }
@@ -222,6 +225,10 @@ export class AuthenticationMainImpl implements AuthenticationMain {
     $onDidChangeSessions(providerId: string, event: theia.AuthenticationProviderAuthenticationSessionsChangeEvent): void {
         this.authenticationService.updateSessions(providerId, event);
     }
+}
+
+function isAuthenticationForceNewSessionOptions(arg: unknown): arg is theia.AuthenticationForceNewSessionOptions {
+    return isObject<theia.AuthenticationForceNewSessionOptions>(arg) && typeof arg.detail === 'string';
 }
 
 async function addAccountUsage(storageService: StorageService, providerId: string, accountName: string, extensionId: string, extensionName: string): Promise<void> {

--- a/packages/plugin-ext/src/plugin/authentication-ext.ts
+++ b/packages/plugin-ext/src/plugin/authentication-ext.ts
@@ -42,12 +42,12 @@ export class AuthenticationExtImpl implements AuthenticationExt {
     }
 
     async getSession(requestingExtension: InternalPlugin, providerId: string, scopes: readonly string[],
-        options: theia.AuthenticationGetSessionOptions & ({ createIfNone: true } | { forceNewSession: true } | { forceNewSession: { detail: string } })):
+        options: theia.AuthenticationGetSessionOptions & ({ createIfNone: true } | { forceNewSession: true } | { forceNewSession: theia.AuthenticationForceNewSessionOptions })):
         Promise<theia.AuthenticationSession>;
     async getSession(requestingExtension: InternalPlugin, providerId: string, scopes: readonly string[],
         options: theia.AuthenticationGetSessionOptions & { forceNewSession: true }): Promise<theia.AuthenticationSession>;
     async getSession(requestingExtension: InternalPlugin, providerId: string, scopes: readonly string[],
-        options: theia.AuthenticationGetSessionOptions & { forceNewSession: { detail: string } }): Promise<theia.AuthenticationSession>;
+        options: theia.AuthenticationGetSessionOptions & { forceNewSession: theia.AuthenticationForceNewSessionOptions }): Promise<theia.AuthenticationSession>;
     async getSession(requestingExtension: InternalPlugin, providerId: string, scopes: readonly string[],
         options: theia.AuthenticationGetSessionOptions): Promise<theia.AuthenticationSession | undefined>;
     async getSession(requestingExtension: InternalPlugin, providerId: string, scopes: readonly string[],

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -13667,6 +13667,17 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Optional options to be used when calling {@link authentication.getSession} with the flag `forceNewSession`.
+     */
+    export interface AuthenticationForceNewSessionOptions {
+        /**
+         * An optional message that will be displayed to the user when we ask to re-authenticate. Providing additional context
+         * as to why you are asking a user to re-authenticate can help increase the odds that they will accept.
+         */
+        detail?: string;
+    }
+
+    /**
      * Options to be used when getting an {@link AuthenticationSession AuthenticationSession} from an {@link AuthenticationProvider AuthenticationProvider}.
      */
     export interface AuthenticationGetSessionOptions {
@@ -13700,7 +13711,7 @@ export module '@theia/plugin' {
          *
          * Defaults to false.
          */
-        forceNewSession?: boolean | { detail: string };
+        forceNewSession?: boolean | AuthenticationForceNewSessionOptions;
 
         /**
          * Whether we should show the indication to sign in in the Accounts menu.


### PR DESCRIPTION
#### What it does

Support of AuthenticationForceNewSessionOptions
A detailed message may be now given rather than a simple boolan when forcing a new session. 

Fixes #12612

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-  extension: 
[authentification-test-0.0.1.zip](https://github.com/eclipsesource/theia/files/12109111/authentification-test-0.0.1.zip)
- source: 
[authentification-test-0.0.1-src.zip](https://github.com/eclipsesource/theia/files/12109113/authentification-test-0.0.1-src.zip)

2. The extension provides a set of commands that simulate the login using a dummy authentification provider. These commands all have a label starting with 'Auth-Test'.

- _Get all sessions_ lists all current sessions or undefined if none exist
- _Get session with no option_ gets the session with the default options. It won't create a new one by default, so no session will be displayed if used first
- _Get session with creationIfNone_ will get any existing session or create a new one if none exists
- _Get session with forceNewSession_ will force a new session (forceNewSession is `true`). Prompt a message with default content.
- _Get session with forceNewSession and detail_ will force a new session (forceNewSession is AuthenticationForceNewSessionOptions with an existing detail string). Prompt a message with content and detail message.

3. On `master` theia, after creating an new session. Invoke _Get session with forceNewSession_  command or _Get session with forceNewSession and detail_  command will always lead to the same result. The message dialog to allow the new session always have the same message.

4. Switch to this PR and run the same tests. The dialog will contain additional detail in the prompt dialog: 'Message based on detail for the force New Session' if _Get session with forceNewSession and detail_ command is invoked.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
