### PR TITLE
[WIP] Enable recording of stopwatch results

### DIFF
--- a/packages/core/src/browser/performance/frontend-stopwatch.ts
+++ b/packages/core/src/browser/performance/frontend-stopwatch.ts
@@ -40,6 +40,7 @@ export class FrontendStopwatch extends Stopwatch {
             performance.mark(endMarker);
 
             let duration: number;
+            let startTime: number;
 
             try {
                 performance.measure(name, startMarker, endMarker);
@@ -47,16 +48,18 @@ export class FrontendStopwatch extends Stopwatch {
                 const entries = performance.getEntriesByName(name);
                 // If no entries, then performance measurement was disabled or failed, so
                 // signal that with a `NaN` result
-                duration = entries.length > 0 ? entries[0].duration : Number.NaN;
+                duration = entries[0].duration ?? Number.NaN;
+                startTime = entries[0].startTime ?? Number.NaN;
             } catch (e) {
                 console.warn(e);
                 duration = Number.NaN;
+                startTime = Number.NaN;
             }
 
             performance.clearMeasures(name);
             performance.clearMarks(startMarker);
             performance.clearMarks(endMarker);
-            return duration;
+            return { startTime, duration };
         }, options);
     }
 };

--- a/packages/core/src/common/performance/measurement.ts
+++ b/packages/core/src/common/performance/measurement.ts
@@ -101,6 +101,11 @@ export interface MeasurementOptions {
      * @see {@link thresholdLogLevel}
      */
     thresholdMillis?: number;
+
+    /**
+     * Flag to indicate whether the stopwatch should cache measurement results for later retrieval.
+     */
+    cacheResults?: boolean
 }
 
 /**
@@ -111,7 +116,7 @@ export interface MeasurementResult {
     name: string;
 
     /** The time when the measurement recording has been started */
-    startTime: number
+    startTime: number;
 
     /**
      * The elapsed time measured, if it has been {@link stop stopped} and measured, or `NaN` if the platform disabled

--- a/packages/core/src/common/performance/measurement.ts
+++ b/packages/core/src/common/performance/measurement.ts
@@ -102,3 +102,28 @@ export interface MeasurementOptions {
      */
     thresholdMillis?: number;
 }
+
+/**
+ * Captures the result of a {@link Measurement} in a serializable format.
+ */
+export interface MeasurementResult {
+    /** The measurement name. This may show up in the performance measurement framework appropriate to the application context. */
+    name: string;
+
+    /** The time when the measurement recording has been started */
+    startTime: number
+
+    /**
+     * The elapsed time measured, if it has been {@link stop stopped} and measured, or `NaN` if the platform disabled
+     * performance measurement.
+     */
+    elapsed: number;
+
+    /*
+    * A specific context of the application in which an activity was measured.
+    */
+    context?: string;
+
+    /** An optional label for the application the start of which (in real time) is the basis of all measurements. */
+    owner?: string;
+}

--- a/packages/core/src/node/performance/node-stopwatch.ts
+++ b/packages/core/src/node/performance/node-stopwatch.ts
@@ -33,7 +33,7 @@ export class NodeStopwatch extends Stopwatch {
 
         return this.createMeasurement(name, () => {
             const duration = performance.now() - startTime;
-            return duration;
+            return { duration, startTime };
         }, options);
     }
 

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -11,6 +11,7 @@
   },
   "theiaExtensions": [
     {
+      "frontend": "lib/browser/metrics-frontend-module",
       "backend": "lib/node/metrics-backend-module"
     }
   ],

--- a/packages/metrics/src/browser/index.ts
+++ b/packages/metrics/src/browser/index.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './metrics-frontend-application-contribution';

--- a/packages/metrics/src/browser/metrics-frontend-application-contribution.ts
+++ b/packages/metrics/src/browser/metrics-frontend-application-contribution.ts
@@ -1,0 +1,39 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { MeasurementResult, Stopwatch } from '@theia/core';
+import { UUID } from '@theia/core/shared/@phosphor/coreutils';
+import { MeasurementNotificationService } from '../common';
+
+@injectable()
+export class MetricsFrontendApplicationContribution implements FrontendApplicationContribution {
+    @inject(Stopwatch)
+    protected stopwatch: Stopwatch;
+
+    @inject(MeasurementNotificationService)
+    protected notificationService: MeasurementNotificationService;
+
+    readonly id = UUID.uuid4();
+
+    initialize(): void {
+        this.stopwatch.onMeasurementResult(result => this.notify(result));
+    }
+
+    protected notify(result: MeasurementResult): void {
+        this.notificationService.onFrontendMeasurement(this.id, result);
+    }
+}

--- a/packages/metrics/src/browser/metrics-frontend-application-contribution.ts
+++ b/packages/metrics/src/browser/metrics-frontend-application-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { MeasurementResult, Stopwatch } from '@theia/core';
+import { ILogger, LogLevel, MeasurementResult, Stopwatch } from '@theia/core';
 import { UUID } from '@theia/core/shared/@phosphor/coreutils';
 import { MeasurementNotificationService } from '../common';
 
@@ -27,9 +27,21 @@ export class MetricsFrontendApplicationContribution implements FrontendApplicati
     @inject(MeasurementNotificationService)
     protected notificationService: MeasurementNotificationService;
 
+    @inject(ILogger)
+    protected logger: ILogger;
+
     readonly id = UUID.uuid4();
 
     initialize(): void {
+        this.doInitialize();
+    }
+
+    protected async doInitialize(): Promise<void> {
+        const logLevel = await this.logger.getLogLevel();
+        if (logLevel !== LogLevel.DEBUG) {
+            return;
+        }
+        this.stopwatch.getCachedResults().forEach(result => this.notify(result));
         this.stopwatch.onMeasurementResult(result => this.notify(result));
     }
 

--- a/packages/metrics/src/browser/metrics-frontend-module.ts
+++ b/packages/metrics/src/browser/metrics-frontend-module.ts
@@ -1,0 +1,28 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { MetricsFrontendApplicationContribution } from './metrics-frontend-application-contribution';
+import { MeasurementNotificationService, measurementNotificationServicePath } from '../common';
+import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+
+export default new ContainerModule(bind => {
+    bind(FrontendApplicationContribution).to(MetricsFrontendApplicationContribution).inSingletonScope();
+    bind(MeasurementNotificationService).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<MeasurementNotificationService>(measurementNotificationServicePath);
+    });
+});

--- a/packages/metrics/src/common/index.ts
+++ b/packages/metrics/src/common/index.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './measurement-notification-service';

--- a/packages/metrics/src/common/measurement-notification-service.ts
+++ b/packages/metrics/src/common/measurement-notification-service.ts
@@ -1,0 +1,29 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MeasurementResult } from '@theia/core';
+
+export const measurementNotificationServicePath = '/services/measurement-notification';
+
+export const MeasurementNotificationService = Symbol('MeasurementNotificationService');
+export interface MeasurementNotificationService {
+    /**
+     * Notify the backend when a fronted stopwatch provides a new measurement.
+     * @param frontendId The unique id associated with the frontend that sends the notification
+     * @param result The new measurement result
+     */
+    onFrontendMeasurement(frontendId: string, result: MeasurementResult): void;
+}

--- a/packages/metrics/src/node/measurement-metrics-contribution.ts
+++ b/packages/metrics/src/node/measurement-metrics-contribution.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MetricsContribution } from './metrics-contribution';
+import { MeasurementResult, Stopwatch } from '@theia/core';
+import { MeasurementNotificationService } from '../common';
+
+const backendId = 'backend';
+const metricsName = 'theia_measurements';
+
+@injectable()
+export class MeasurementMetricsContribution implements MetricsContribution, MeasurementNotificationService {
+    @inject(Stopwatch)
+    protected backendStopwatch: Stopwatch;
+
+    protected metrics = '';
+    protected frontendCounter = new Map<string, string>();
+
+    startCollecting(): void {
+        this.metrics += `# HELP ${metricsName} Theia stopwatch measurement results.\n`;
+        this.metrics += `# TYPE ${metricsName} gauge\n`;
+        this.backendStopwatch.onMeasurementResult(result => this.onBackendMeasurement(result));
+    }
+
+    getMetrics(): string {
+        return this.metrics;
+    }
+
+    protected appendMetricsValue(id: string, result: MeasurementResult): void {
+        const { name, elapsed, startTime, context, owner } = result;
+        const labels: string = `id="${id}", name="${name}" ,startTime="${startTime}", elapsed="${elapsed}", owner="${owner}", context="${context}"`;
+        const metricsValue = `${metricsName}{${labels}} ${elapsed}`;
+        this.metrics += (metricsValue + '\n');
+    }
+
+    protected onBackendMeasurement(result: MeasurementResult): void {
+        this.appendMetricsValue(backendId, result);
+    }
+
+    protected createFrontendCounterId(frontendId: string): string {
+        const counterId = `frontend-${this.frontendCounter.size + 1}`;
+        this.frontendCounter.set(frontendId, counterId);
+        return counterId;
+    }
+
+    protected toCounterId(frontendId: string): string {
+        return this.frontendCounter.get(frontendId) ?? this.createFrontendCounterId(frontendId);
+    }
+
+    onFrontendMeasurement(frontendId: string, result: MeasurementResult): void {
+        this.appendMetricsValue(this.toCounterId(frontendId), result);
+    }
+
+}

--- a/packages/metrics/src/node/metrics-backend-module.ts
+++ b/packages/metrics/src/node/metrics-backend-module.ts
@@ -16,17 +16,26 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
-import { bindContributionProvider } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler, bindContributionProvider } from '@theia/core/lib/common';
 import { MetricsContribution } from './metrics-contribution';
 import { NodeMetricsContribution } from './node-metrics-contribution';
 import { ExtensionMetricsContribution } from './extensions-metrics-contribution';
 import { MetricsBackendApplicationContribution } from './metrics-backend-application-contribution';
+import { measurementNotificationServicePath } from '../common';
+import { MeasurementMetricsContribution } from './measurement-metrics-contribution';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, MetricsContribution);
     bind(MetricsContribution).to(NodeMetricsContribution).inSingletonScope();
     bind(MetricsContribution).to(ExtensionMetricsContribution).inSingletonScope();
 
+    bind(MeasurementMetricsContribution).toSelf().inSingletonScope();
+    bind(MetricsContribution).toService(MeasurementMetricsContribution);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(measurementNotificationServicePath,
+            () => ctx.container.get(MeasurementMetricsContribution)));
+
+    bind(MetricsBackendApplicationContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).to(MetricsBackendApplicationContribution).inSingletonScope();
 
 });

--- a/packages/metrics/src/node/metrics-backend-module.ts
+++ b/packages/metrics/src/node/metrics-backend-module.ts
@@ -22,20 +22,19 @@ import { NodeMetricsContribution } from './node-metrics-contribution';
 import { ExtensionMetricsContribution } from './extensions-metrics-contribution';
 import { MetricsBackendApplicationContribution } from './metrics-backend-application-contribution';
 import { measurementNotificationServicePath } from '../common';
-import { MeasurementMetricsContribution } from './measurement-metrics-contribution';
+import { MeasurementMetricsBackendContribution } from './measurement-metrics-contribution';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, MetricsContribution);
     bind(MetricsContribution).to(NodeMetricsContribution).inSingletonScope();
     bind(MetricsContribution).to(ExtensionMetricsContribution).inSingletonScope();
 
-    bind(MeasurementMetricsContribution).toSelf().inSingletonScope();
-    bind(MetricsContribution).toService(MeasurementMetricsContribution);
+    bind(MeasurementMetricsBackendContribution).toSelf().inSingletonScope();
+    bind(MetricsContribution).toService(MeasurementMetricsBackendContribution);
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new RpcConnectionHandler(measurementNotificationServicePath,
-            () => ctx.container.get(MeasurementMetricsContribution)));
+            () => ctx.container.get(MeasurementMetricsBackendContribution)));
 
-    bind(MetricsBackendApplicationContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).to(MetricsBackendApplicationContribution).inSingletonScope();
 
 });


### PR DESCRIPTION
Introduce `MeasurementResults` that capture a stopwatch execution in a serializable format. Add `onMeasurementResult` event emitter to stopwatch class. Add a metrics contribution to `@theia/metrics` that collects all measurement results of frontend and backend processes

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
