### PR TITLE
Open initial electron window early and reuse it later

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -341,7 +341,9 @@ export class DebugEditorModel implements Disposable {
                 const line = range.startLineNumber;
                 const column = range.startColumn;
                 const oldBreakpoint = this.breakpointRanges.get(decoration)?.[1];
-                const breakpoint = SourceBreakpoint.create(uri, { line, column }, oldBreakpoint);
+                const isLineBreakpoint = oldBreakpoint?.raw.line !== undefined && oldBreakpoint?.raw.column === undefined;
+                const change = isLineBreakpoint ? { line } : { line, column };
+                const breakpoint = SourceBreakpoint.create(uri, change, oldBreakpoint);
                 breakpoints.push(breakpoint);
                 lines.add(line);
             }


### PR DESCRIPTION
This avoids having a rather long pause from Theia start until something is visibly coming up. In my initial experiment, I observe the empty window showing up ~1.5s earlier than without this PR. To enable an easier comparison, we use the environment variable `SKIP_INITIAL_WINDOW` to deactivate the creation of an initial window. This way, you can easily analyze the difference:

`yarn electron start` (with early initial window)
`SKIP_INITIAL_WINDOW=1 yarn electron start` (status before this change)

Change-Id: I58a022005888398cc02b79025df76adc739b3e6e