### PR TITLE
Partial support of provideDocumentRangesFormattingEdits 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## v1.43.0 - Unreleased
 
+- [editor] add partial support of 'provideDocumentRangesFormattingEdits' in the `DocumentRangeFormattingEditProvider` VS Code API []()
+
 <a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.43.0)</a>
 
 - [core] removed `SETTINGS_OPEN` menupath constant - replaced by `MANAGE_GENERAL` [#12803](https://github.com/eclipse-theia/theia/pull/12803)

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1615,6 +1615,8 @@ export interface LanguagesExt {
         options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range,
         options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
+    $provideDocumentRangesFormattingEdits(handle: number, resource: UriComponents, ranges: Range[],
+        options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
     $provideOnTypeFormattingEdits(
         handle: number,
         resource: UriComponents,

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -695,7 +695,11 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
             extensionId: new ExtensionIdentifier(pluginInfo.id),
             displayName: pluginInfo.name,
             provideDocumentRangeFormattingEdits: (model, range: Range, options, token) =>
-                this.provideDocumentRangeFormattingEdits(handle, model, range, options, token)
+                this.provideDocumentRangeFormattingEdits(handle, model, range, options, token),
+            // @monaco-uplift
+            // after updating monaco > 1.81, the monaco DocumentRangeFormattingEditProvider will have this additional method
+            // provideDocumentRangesFormattingEdits: (model, ranges: Range[], options, token) =>
+            //    this.provideDocumentRangeFormattingEdits(handle, model, ranges, options, token),
         };
 
         return provider;
@@ -704,6 +708,11 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
     protected provideDocumentRangeFormattingEdits(handle: number, model: monaco.editor.ITextModel,
         range: Range, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
         return this.proxy.$provideDocumentRangeFormattingEdits(handle, model.uri, range, options, token);
+    }
+
+    protected provideDocumentRangesFormattingEdits(handle: number, model: monaco.editor.ITextModel,
+        ranges: Range[], options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
+        return this.proxy.$provideDocumentRangesFormattingEdits(handle, model.uri, ranges, options, token);
     }
 
     $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -517,6 +517,11 @@ export class LanguagesExtImpl implements LanguagesExt {
         options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         return this.withAdapter(handle, RangeFormattingAdapter, adapter => adapter.provideDocumentRangeFormattingEdits(URI.revive(resource), range, options, token), undefined);
     }
+
+    $provideDocumentRangesFormattingEdits(handle: number, resource: UriComponents, ranges: Range[],
+        options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
+        return this.withAdapter(handle, RangeFormattingAdapter, adapter => adapter.provideDocumentRangesFormattingEdits(URI.revive(resource), ranges, options, token), undefined);
+    }
     // ### Document Range Formatting Edit end
 
     // ### On Type Formatting Edit begin

--- a/packages/plugin-ext/src/plugin/languages/range-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/range-formatting.ts
@@ -45,4 +45,26 @@ export class RangeFormattingAdapter {
         });
     }
 
+    provideDocumentRangesFormattingEdits(resource: URI, ranges: Range[], options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There are no document for ${resource}`));
+        }
+
+        const doc = document.document;
+
+        if (typeof this.provider['provideDocumentRangesFormattingEdits'] === 'function') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const result = Promise.resolve(this.provider.provideDocumentRangesFormattingEdits(doc, ranges.map(Converter.toRange), <any>options, token)).then(value => {
+                if (Array.isArray(value)) {
+                    return value.map(Converter.fromTextEdit);
+                }
+                return undefined;
+            });
+            return result;
+        }
+
+        return Promise.resolve(undefined);
+    }
+
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10240,6 +10240,26 @@ export module '@theia/plugin' {
             options: FormattingOptions,
             token: CancellationToken | undefined
         ): ProviderResult<TextEdit[] | undefined>;
+
+        /**
+         * Provide formatting edits for multiple ranges in a document.
+         *
+         * This function is optional but allows a formatter to perform faster when formatting only modified ranges or when
+         * formatting a large number of selections.
+         *
+         * The given ranges are hints and providers can decide to format a smaller
+         * or larger range. Often this is done by adjusting the start and end
+         * of the range to full syntax nodes.
+         *
+         * @param document The document in which the command was invoked.
+         * @param ranges The ranges which should be formatted.
+         * @param options Options controlling formatting.
+         * @param token A cancellation token.
+         * @returns A set of text edits or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined`, `null`, or an empty array.
+         * @stubbed
+         */
+        provideDocumentRangesFormattingEdits?(document: TextDocument, ranges: Range[], options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Support of provideDocumentRangesFormattingEdits in DocumentRangeFormattingEditProvider

Code 1.82 finalized the support for the _provideDocumentRangesFormattingEdits_ in _DocumentRangeFormattingEditProvider_. 
This commit is a partial contribution. It adds the new method to the API and base implementation in the language main/ext, but the implementation cannot be fully done until the Monaco dependency has been upgraded.
It is also hard to test, even in vs code, due to missing specific command for formatting on several ranges. Currently, only a command with a single range can be triggered:  https://code.visualstudio.com/api/references/commands

API report after pull request:
![afterPR-12939](https://github.com/eclipsesource/theia/assets/3964263/d3700a68-31d5-44dd-9512-6a75084a2823)

Note: Changelog will be modified when pull request will be opened on main repo.

Fixes #12939  

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-  extension: 
[text-formatting-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/12882962/text-formatting-sample-0.0.1.zip)

- source: 
[text-formatting-sample-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/12882966/text-formatting-sample-0.0.1-src.zip)


2. The extension provides formatting for simple and multiple range for typescript files. No issues shall be logged when it is installed. Formatting may also be performed once formatting is enabled for several ranges. Only single range can be tested currently. 
Formatting for a simple range adds '_' before and after the selection. '//' shall be added to each selected text when using multiple range. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
