### PR TITLE
[vscode] support of editor.indentSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [task] prevent task widget title from being changed by task process [#13003](https://github.com/eclipse-theia/theia/pull/13003)
 - [vscode] Added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
+- [vscode] Added support for editor.indentSize API [#13105](https://github.com/eclipse-theia/theia/pull/13105) - contributed on behalf of STMicroelectronics
 
 ## v1.43.0 - 10/26/2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 ## v1.44.0
+
 - [task] prevent task widget title from being changed by task process [#13003](https://github.com/eclipse-theia/theia/pull/13003)
+- [vscode] Added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
 
 ## v1.43.0 - 10/26/2023
 

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -265,10 +265,12 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             ({
                 label: size === tabSize ? size + '   ' + nls.localizeByDefault('Configured Tab Size') : size.toString(),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                execute: () => model.updateOptions({
-                    tabSize: size || tabSize,
-                    insertSpaces: useSpaces
-                })
+                execute: () =>
+                    model.updateOptions({
+                        tabSize: size || tabSize,
+                        indentSize: size || tabSize,
+                        insertSpaces: useSpaces
+                    })
             })
             );
             this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: nls.localizeByDefault('Select Tab Size for Current File') });

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -67,8 +67,9 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
         if (editor && editorModel) {
             const modelOptions = editorModel.getOptions();
             const tabSize = modelOptions.tabSize;
+            const indentSize = modelOptions.indentSize;
             const spaceOrTabSizeMessage = modelOptions.insertSpaces
-                ? nls.localizeByDefault('Spaces: {0}', tabSize)
+                ? nls.localizeByDefault('Spaces: {0}', indentSize)
                 : nls.localizeByDefault('Tab Size: {0}', tabSize);
             this.statusBar.setElement('editor-status-tabbing-config', {
                 text: spaceOrTabSizeMessage,

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -127,12 +127,15 @@ export class MonacoTextModelService implements ITextModelService {
 
     protected readonly modelOptions: { [name: string]: (keyof ITextModelUpdateOptions | undefined) } = {
         'editor.tabSize': 'tabSize',
-        'editor.insertSpaces': 'insertSpaces'
+        'editor.insertSpaces': 'insertSpaces',
+        'editor.indentSize': 'tabSize'
     };
 
     protected toModelOption(editorPreference: EditorPreferenceChange['preferenceName']): keyof ITextModelUpdateOptions | undefined {
         switch (editorPreference) {
             case 'editor.tabSize': return 'tabSize';
+            // monaco-uplift: uncomment this line once 'editor.indentSize' preference is available
+            //  case 'editor.indentSize': return 'tabSize';
             case 'editor.insertSpaces': return 'insertSpaces';
             case 'editor.bracketPairColorization.enabled':
             case 'editor.bracketPairColorization.independentColorPoolPerBracketType':
@@ -170,6 +173,8 @@ export class MonacoTextModelService implements ITextModelService {
         const overrideIdentifier = typeof arg === 'string' ? undefined : arg.languageId;
         return {
             tabSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
+            // monaco-uplift: when available, switch to 'editor.indentSize' preference.
+            indentSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
             insertSpaces: this.editorPreferences.get({ preferenceName: 'editor.insertSpaces', overrideIdentifier }, undefined, uri),
             bracketColorizationOptions: {
                 enabled: this.editorPreferences.get({ preferenceName: 'editor.bracketPairColorization.enabled', overrideIdentifier }, undefined, uri),

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1124,6 +1124,7 @@ export interface Selection {
 
 export interface TextEditorConfiguration {
     tabSize: number;
+    indentSize: number;
     insertSpaces: boolean;
     cursorStyle: TextEditorCursorStyle;
     lineNumbers: TextEditorLineNumbersStyle;
@@ -1131,6 +1132,7 @@ export interface TextEditorConfiguration {
 
 export interface TextEditorConfigurationUpdate {
     tabSize?: number | 'auto';
+    indentSize?: number | 'tabSize';
     insertSpaces?: boolean | 'auto';
     cursorStyle?: TextEditorCursorStyle;
     lineNumbers?: TextEditorLineNumbersStyle;

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -194,6 +194,13 @@ export class TextEditorMain implements Disposable {
         if (typeof newConfiguration.tabSize !== 'undefined') {
             newOpts.tabSize = newConfiguration.tabSize;
         }
+        if (typeof newConfiguration.indentSize !== 'undefined') {
+            if (newConfiguration.indentSize === 'tabSize') {
+                newOpts.indentSize = newConfiguration.tabSize;
+            } else if (typeof newConfiguration.indentSize == 'number') {
+                newOpts.indentSize = newConfiguration.indentSize;
+            }
+        }
         this.model.updateOptions(newOpts);
     }
 
@@ -408,6 +415,7 @@ export class TextEditorPropertiesMain {
         const modelOptions = model.getOptions();
         return {
             insertSpaces: modelOptions.insertSpaces,
+            indentSize: modelOptions.indentSize,
             tabSize: modelOptions.tabSize,
             cursorStyle,
             lineNumbers,
@@ -443,6 +451,7 @@ export class TextEditorPropertiesMain {
         return (
             a.tabSize === b.tabSize
             && a.insertSpaces === b.insertSpaces
+            && a.indentSize === b.indentSize
             && a.cursorStyle === b.cursorStyle
             && a.lineNumbers === b.lineNumbers
         );

--- a/packages/plugin-ext/src/main/browser/webview/pre/host.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/host.js
@@ -36,7 +36,7 @@
                         break;
                     }
                 }
-                if (sourceIsChildFrame && e.data && (e.data.command === 'onmessage' || e.data.command === 'do-update-state')) {
+                if (sourceIsChildFrame && e.data && (e.data.command === 'onmessage' || e.data.command === 'do-update-state' || e.data.command === 'onconsole')) {
                     this.postMessage(e.data.command, e.data.data);
                 } else if (sourceIsChildFrame || sourceIsSelfOrParentFrame) {
                     const channel = e.data.channel;

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -144,40 +144,65 @@
      * @param {*} [state]
      * @return {string}
      */
-    function getVsCodeApiScript(state) {
+    function getDefaultScript(state) {
         return `
-        const acquireVsCodeApi = (function() {
-            const originalPostMessage = window.parent.postMessage.bind(window.parent);
-            const targetOrigin = '*';
-            let acquired = false;
+const acquireVsCodeApi = (function() {
+    const originalPostMessage = window.parent.postMessage.bind(window.parent);
+    const originalConsole = {...console};
+    const targetOrigin = '*';
+    let acquired = false;
 
-            let state = ${state ? `JSON.parse(${JSON.stringify(state)})` : undefined};
+    let state = ${state ? `JSON.parse(${JSON.stringify(state)})` : undefined};
 
-            return () => {
-                if (acquired) {
-                    throw new Error('An instance of the VS Code API has already been acquired');
-                }
-                acquired = true;
-                return Object.freeze({
-                    postMessage: function(msg) {
-                        return originalPostMessage({ command: 'onmessage', data: msg }, targetOrigin);
-                    },
-                    setState: function(newState) {
-                        state = newState;
-                        originalPostMessage({ command: 'do-update-state', data: JSON.stringify(newState) }, targetOrigin);
-                        return newState;
-                    },
-                    getState: function() {
-                        return state;
-                    }
-                });
-            };
-        })();
-        const acquireTheiaApi = acquireVsCodeApi;
-        delete window.parent;
-        delete window.top;
-        delete window.frameElement;
-        `;
+    const forwardConsoleLog = (level, msg, args) => {
+        let message, optionalParams;
+        try {
+            if (msg) {
+                message = JSON.stringify(msg) ?? null;
+            }
+            if (args) {
+                optionalParams = JSON.stringify(args) ?? null;
+            }
+        } catch (e) {
+            // Log non serializable objects inside of view
+            originalConsole[level](msg, args);
+            return;
+        }
+        originalPostMessage({ command: 'onconsole', data: { level, message, optionalParams } }, targetOrigin);
+    };
+
+    console.log = (message, args) => forwardConsoleLog('log', message, args);
+    console.info = (message, args) => forwardConsoleLog('info', message, args);
+    console.warn = (message, args) => forwardConsoleLog('warn', message, args);
+    console.error = (message, args) => forwardConsoleLog('error', message, args);
+    console.debug = (message, args) => forwardConsoleLog('debug', message, args);
+    console.trace = (message, args) => forwardConsoleLog('trace', message, args);
+
+    return () => {
+        if (acquired) {
+            throw new Error('An instance of the VS Code API has already been acquired');
+        }
+        acquired = true;
+        return Object.freeze({
+            postMessage: function (msg) {
+                return originalPostMessage({ command: 'onmessage', data: msg }, targetOrigin);
+            },
+            setState: function (newState) {
+                state = newState;
+                originalPostMessage({ command: 'do-update-state', data: JSON.stringify(newState) }, targetOrigin);
+                return newState;
+            },
+            getState: function () {
+                return state;
+            }
+        });
+    };
+})();
+const acquireTheiaApi = acquireVsCodeApi;
+delete window.parent;
+delete window.top;
+delete window.frameElement;        
+`;
     }
 
     /**
@@ -369,7 +394,7 @@
             // apply default script
             if (options.allowScripts) {
                 const defaultScript = newDocument.createElement('script');
-                defaultScript.textContent = getVsCodeApiScript(data.state);
+                defaultScript.textContent = getDefaultScript(data.state);
                 newDocument.head.prepend(defaultScript);
             }
 

--- a/packages/plugin-ext/src/plugin/text-editor.ts
+++ b/packages/plugin-ext/src/plugin/text-editor.ts
@@ -277,7 +277,8 @@ export class TextEditorExt implements theia.TextEditor {
 }
 
 export class TextEditorOptionsExt implements theia.TextEditorOptions {
-    private _tabSize?: number;
+    private _tabSize: number;
+    private _indentSize: number;
     private _insertSpace: boolean;
     private _cursorStyle: TextEditorCursorStyle;
     private _lineNumbers: TextEditorLineNumbersStyle;
@@ -289,12 +290,13 @@ export class TextEditorOptionsExt implements theia.TextEditorOptions {
 
     accept(source: TextEditorConfiguration): void {
         this._tabSize = source.tabSize;
+        this._indentSize = source.indentSize;
         this._insertSpace = source.insertSpaces;
         this._cursorStyle = source.cursorStyle;
         this._lineNumbers = source.lineNumbers;
     }
 
-    get tabSize(): number | string | undefined {
+    get tabSize(): number {
         return this._tabSize;
     }
 
@@ -305,10 +307,10 @@ export class TextEditorOptionsExt implements theia.TextEditorOptions {
         }
 
         if (typeof tabSize === 'number') {
-            if (this.tabSize === tabSize) {
+            if (this._tabSize === tabSize) {
                 return;
             }
-            this.tabSize = tabSize;
+            this._tabSize = tabSize;
         }
         warnOnError(this.proxy.$trySetOptions(this.id, {
             tabSize
@@ -318,6 +320,48 @@ export class TextEditorOptionsExt implements theia.TextEditorOptions {
     private validateTabSize(val: number | string | undefined): number | 'auto' | undefined {
         if (val === 'auto') {
             return 'auto';
+        }
+
+        if (typeof val === 'number') {
+            const r = Math.floor(val);
+            return r > 0 ? r : undefined;
+        }
+        if (typeof val === 'string') {
+            const r = parseInt(val, undefined);
+            if (isNaN(r)) {
+                return undefined;
+            }
+            return r > 0 ? r : undefined;
+        }
+        return undefined;
+    }
+
+    get indentSize(): number {
+        return this._indentSize;
+    }
+
+    set indentSize(val: number | string | undefined) {
+        const indentSize = this.validateIndentSize(val);
+        if (!indentSize) {
+            return; // ignore invalid values
+        }
+
+        if (typeof indentSize === 'number') {
+            if (this._indentSize === indentSize) {
+                return;
+            }
+            this._indentSize = indentSize;
+        } else if (val === 'tabSize') {
+            this._indentSize = this._tabSize!;
+        }
+        warnOnError(this.proxy.$trySetOptions(this.id, {
+            indentSize
+        }));
+    }
+
+    private validateIndentSize(val: number | string | undefined): number | 'tabSize' | undefined {
+        if (val === 'tabSize') {
+            return 'tabSize';
         }
 
         if (typeof val === 'number') {
@@ -392,6 +436,19 @@ export class TextEditorOptionsExt implements theia.TextEditorOptions {
                 this._tabSize = tabSize;
                 hasUpdate = true;
                 configurationUpdate.tabSize = tabSize;
+            }
+        }
+
+        if (typeof newOptions.indentSize !== 'undefined') {
+            const indentSize = this.validateIndentSize(newOptions.indentSize);
+            if (indentSize === 'tabSize') {
+                hasUpdate = true;
+                configurationUpdate.indentSize = indentSize;
+            } else if (typeof indentSize === 'number' && this._indentSize !== indentSize) {
+                // reflect the new indentSize value immediately
+                this._indentSize = indentSize;
+                hasUpdate = true;
+                configurationUpdate.indentSize = indentSize;
             }
         }
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1657,6 +1657,7 @@ export class CodeActionKind {
     public static readonly Source = CodeActionKind.Empty.append('source');
     public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
     public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');
+    public static readonly Notebook = CodeActionKind.Empty.append('notebook');
 
     constructor(
         public readonly value: string

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1910,6 +1910,14 @@ export module '@theia/plugin' {
         tabSize?: number | string;
 
         /**
+         * The number of spaces to insert when {@link TextEditorOptions.insertSpaces insertSpaces} is true.
+         *
+         * When getting a text editor's options, this property will always be a number (resolved).
+         * When setting a text editor's options, this property is optional and it can be a number or `"tabSize"`.
+         */
+        indentSize?: number | string;
+
+        /**
          * When pressing Tab insert {@link TextEditorOptions.tabSize n} spaces.
          * When getting a text editor's options, this property will always be a boolean (resolved).
          * When setting a text editor's options, this property is optional and it can be a boolean or `"auto"`.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10001,6 +10001,24 @@ export module '@theia/plugin' {
          */
         static readonly SourceFixAll: CodeActionKind;
 
+        /**
+         * Base kind for all code actions applying to the enitre notebook's scope. CodeActionKinds using
+         * this should always begin with `notebook.`
+         *
+         * This requires that new CodeActions be created for it and contributed via extensions.
+         * Pre-existing kinds can not just have the new `notebook.` prefix added to them, as the functionality
+         * is unique to the full-notebook scope.
+         *
+         * Notebook CodeActionKinds can be initialized as either of the following (both resulting in `notebook.source.xyz`):
+         * - `const newKind =  CodeActionKind.Notebook.append(CodeActionKind.Source.append('xyz').value)`
+         * - `const newKind =  CodeActionKind.Notebook.append('source.xyz')`
+         *
+         * Example Kinds/Actions:
+         * - `notebook.source.organizeImports` (might move all imports to a new top cell)
+         * - `notebook.source.normalizeVariableNames` (might rename all variables to a standardized casing format)
+         */
+        static readonly Notebook: CodeActionKind;
+
         private constructor(value: string);
 
         /**


### PR DESCRIPTION
#### What it does

Fix missing API TextEditorOptions.indentSize made public on vscode 1.83 (was a proposed API before). 
The behavior is available, but the preference requires an uplift of the monaco version. It is not yet available in the generated preferences. 

Note; changelog will be pushed once PR is created against main repo.

Fixes #13058

Contributed on behalf of ST Microelectronics

#### How to test 
The test can be done on a text file, using "Indent using spaces" and "Indent using tabs" commands. The behavior should be the same as before. Only the internals have changed. 
The preferences test has to wait the monaco uplift.

The following provided extension can also show the value of identSize when the value has changed with an information message:
- zip: [indent-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13347091/indent-sample-0.0.1.zip)
- src: [indent-sample-src-0.01.zip](https://github.com/eclipse-theia/theia/files/13347093/indent-sample-src-0.01.zip)

#### Follow-ups

Preferences need to be supported once a monaco uplift has been performed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

