### PR TITLE
[vscode] Notebook CodeActionKind Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 ## v1.44.0
+
 - [task] prevent task widget title from being changed by task process [#13003](https://github.com/eclipse-theia/theia/pull/13003)
+- [vscode] Added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
 
 ## v1.43.0 - 10/26/2023
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1657,6 +1657,7 @@ export class CodeActionKind {
     public static readonly Source = CodeActionKind.Empty.append('source');
     public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
     public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');
+    public static readonly Notebook = CodeActionKind.Empty.append('notebook');
 
     constructor(
         public readonly value: string

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10001,6 +10001,24 @@ export module '@theia/plugin' {
          */
         static readonly SourceFixAll: CodeActionKind;
 
+        /**
+         * Base kind for all code actions applying to the enitre notebook's scope. CodeActionKinds using
+         * this should always begin with `notebook.`
+         *
+         * This requires that new CodeActions be created for it and contributed via extensions.
+         * Pre-existing kinds can not just have the new `notebook.` prefix added to them, as the functionality
+         * is unique to the full-notebook scope.
+         *
+         * Notebook CodeActionKinds can be initialized as either of the following (both resulting in `notebook.source.xyz`):
+         * - `const newKind =  CodeActionKind.Notebook.append(CodeActionKind.Source.append('xyz').value)`
+         * - `const newKind =  CodeActionKind.Notebook.append('source.xyz')`
+         *
+         * Example Kinds/Actions:
+         * - `notebook.source.organizeImports` (might move all imports to a new top cell)
+         * - `notebook.source.normalizeVariableNames` (might rename all variables to a standardized casing format)
+         */
+        static readonly Notebook: CodeActionKind;
+
         private constructor(value: string);
 
         /**


### PR DESCRIPTION
#### What it does

Fix missing API CodeActionKind notebook made public on vscode 1.83.
The static kind is available for notebooks, which allows to activate an extension without troubles and to register notebook edit values.
As a remark, the preferences do not align on the current vscode versions for 'editor: Code Actions On Save' possible values. There are no more boolean, but enum  (automatic / explicit / etc.).  
As a second remark, the save Participant behavior is not yet supported, and the adaptations required for notebook saveParticipants are not yet available. So all adaptations made on vscode issue [192248](https://github.com/microsoft/vscode/pull/192248) cannot be implemented.


Note: changelog will be pushed once PR is created against main repo.

Fixes #13059 

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install the following extension on Theia master:
- zip:
[notebook-onwillsave-extension-0.0.3.zip](https://github.com/eclipse-theia/theia/files/13392168/notebook-onwillsave-extension-0.0.3.zip)
- src:  
[notebook-onwillsave-extension-0.0.3-src.zip](https://github.com/eclipse-theia/theia/files/13392169/notebook-onwillsave-extension-0.0.3-src.zip)

2. Start browser theia
3. On activation, the following error is shown:
![notebook-codeactionkind-before](https://github.com/eclipse-theia/theia/assets/3964263/d4e87f77-3efc-44d9-80a6-350289a88876)

4. Switch to the branch and rebuild
5. Starting with the extension,  no more errors shall popup
6. an action item shall come when in the cell of a notebook editor. I created a 'test.ipynb' file for that with dummy content. The action will add content to the cell when selected.

#### Follow-ups

- Implement properly the saveParticipants and check the specific behavior for notebooks works as expected. see vscode issue for that.
- The preference 'editor:Code Actions On Save' shall be updated as soon as the monaco version is uplifted 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)