### PR TITLE
Add code response part renderer

### DIFF
--- a/packages/ai-chat-ui/package.json
+++ b/packages/ai-chat-ui/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/ai-chat": "1.49.0",
     "@theia/core": "1.49.0",
+    "@theia/editor": "1.49.0",
     "@theia/filesystem": "1.49.0",
     "@theia/workspace": "1.49.0",
     "highlight.js": "^11.10.0",

--- a/packages/ai-chat-ui/package.json
+++ b/packages/ai-chat-ui/package.json
@@ -7,8 +7,8 @@
     "@theia/core": "1.49.0",
     "@theia/editor": "1.49.0",
     "@theia/filesystem": "1.49.0",
+    "@theia/monaco": "1.49.0",
     "@theia/workspace": "1.49.0",
-    "highlight.js": "^11.10.0",
     "minimatch": "^5.1.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"

--- a/packages/ai-chat-ui/package.json
+++ b/packages/ai-chat-ui/package.json
@@ -7,6 +7,7 @@
     "@theia/core": "1.49.0",
     "@theia/filesystem": "1.49.0",
     "@theia/workspace": "1.49.0",
+    "highlight.js": "^11.10.0",
     "minimatch": "^5.1.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0"

--- a/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
@@ -25,7 +25,7 @@ import { ChatInputWidget } from './chat-input-widget';
 import { ChatResponsePartRenderer } from './types';
 
 import '../../src/browser/style/index.css';
-import { MarkdownPartRenderer, TextPartRenderer } from './chat-response-renderer';
+import { CodePartRenderer, MarkdownPartRenderer, TextPartRenderer } from './chat-response-renderer';
 
 export default new ContainerModule(bind => {
     bindViewContribution(bind, AIChatContribution);
@@ -53,4 +53,5 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
     bind(ChatResponsePartRenderer).to(TextPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(MarkdownPartRenderer).inSingletonScope();
+    bind(ChatResponsePartRenderer).to(CodePartRenderer).inSingletonScope();
 });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -140,6 +140,7 @@ export const CodeWrapper = (props: {
     // eslint-disable-next-line no-null/no-null
     const ref = React.useRef<HTMLDivElement | null>(null);
 
+
     const createInputElement = async () => {
         const resource = await props.untitledResourceResolver.createUntitledResource(undefined, props.language);
         const editor = await props.editorProvider.createInline(resource.uri, ref.current!, {
@@ -147,12 +148,21 @@ export const CodeWrapper = (props: {
             autoSizing: true,
             maxHeight: undefined
         });
+        console.log("RENDERER", props.content);
         editor.document.textEditorModel.setValue(props.content);
+        return editor;
     };
 
     React.useEffect(() => {
-        createInputElement();
-    }, []);
+        const editor = createInputElement();
+        return () => {
+            editor.then(e => {
+                // eslint-disable-next-line no-null/no-null
+                ref.current = null;
+                e.dispose();
+            });
+        }
+    }, [props.content]);
 
     return <div ref={ref}></div>;
 };

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -28,6 +28,7 @@ import hljs from 'highlight.js';
 import 'highlight.js/styles/github.css';
 import * as DOMPurify from '@theia/core/shared/dompurify';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { URI } from '@theia/core';
 
 @injectable()
 export class CodePartRenderer
@@ -49,7 +50,8 @@ export class CodePartRenderer
         // FIXME do not hard code the language
         const highlightedCode = hljs.highlight(response.code, { language: 'typescript' }).value;
 
-        const title = response.location?.uri?.toString() ?? 'Generated Code';
+        const title = this.getTitle(response.location?.uri);
+
         return (
             <div className="theia-CodePartRenderer-root">
                 <div className="theia-CodePartRenderer-top">
@@ -67,6 +69,10 @@ export class CodePartRenderer
                 </div>
             </div>
         );
+    }
+
+    private getTitle(uri: URI | undefined): string {
+        return uri?.path?.toString().split('/').pop() ?? 'Generated Code';
     }
 
     private writeCodeToClipboard(code: string): void {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -29,6 +29,7 @@ import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
 import { ChatResponsePartRenderer } from '../types';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 @injectable()
 export class CodePartRenderer
@@ -139,7 +140,7 @@ export const CodeWrapper = (props: {
 }) => {
     // eslint-disable-next-line no-null/no-null
     const ref = React.useRef<HTMLDivElement | null>(null);
-
+    const editorRef = React.useRef<MonacoEditor | undefined>(undefined);
 
     const createInputElement = async () => {
         const resource = await props.untitledResourceResolver.createUntitledResource(undefined, props.language);
@@ -148,19 +149,22 @@ export const CodeWrapper = (props: {
             autoSizing: true,
             maxHeight: undefined
         });
-        console.log("RENDERER", props.content);
         editor.document.textEditorModel.setValue(props.content);
-        return editor;
+        editorRef.current = editor;
     };
 
     React.useEffect(() => {
-        const editor = createInputElement();
+        createInputElement();
         return () => {
-            editor.then(e => {
-                // eslint-disable-next-line no-null/no-null
-                ref.current = null;
-                e.dispose();
-            });
+            if (editorRef.current) {
+                editorRef.current.dispose();
+            }
+        };
+    }, []);
+
+    React.useEffect(() => {
+        if (editorRef.current) {
+            editorRef.current.document.textEditorModel.setValue(props.content);
         }
     }, [props.content]);
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -61,8 +61,8 @@ export class CodePartRenderer
                 <div className="theia-CodePartRenderer-top">
                     <div className="theia-CodePartRenderer-left">{this.renderTitle(response)}</div>
                     <div className="theia-CodePartRenderer-right">
-                        <button onClick={this.writeCodeToClipboard.bind(this, response.code)}>Copy</button>
-                        <button onClick={this.insertCode.bind(this, response.code)}>Insert at Cursor</button>
+                        <CopyToClipboardButton code={response.code} clipboardService={this.clipboardService} />
+                        <InsertCodeAtCursorButton code={response.code} editorManager={this.editorManager} />
                     </div>
                 </div>
                 <div className="theia-CodePartRenderer-separator"></div>
@@ -90,28 +90,6 @@ export class CodePartRenderer
         return uri?.path?.toString().split('/').pop() ?? 'Generated Code';
     }
 
-    private writeCodeToClipboard(code: string): void {
-        this.clipboardService.writeText(code);
-    }
-
-    protected insertCode(code: string): void {
-        const editor = this.editorManager.currentEditor;
-        if (editor) {
-            const currentEditor = editor.editor;
-            const selection = currentEditor.selection;
-
-            // Insert the text at the current cursor position
-            // If there is a selection, replace the selection with the text
-            currentEditor.executeEdits([{
-                range: {
-                    start: selection.start,
-                    end: selection.end
-                },
-                newText: code
-            }]);
-        }
-    }
-
     /**
      * Opens a file and moves the cursor to the specified position.
      *
@@ -128,6 +106,36 @@ export class CodePartRenderer
         }
     }
 }
+
+const CopyToClipboardButton = (props: { code: string, clipboardService: ClipboardService }) => {
+    const { code, clipboardService } = props;
+    const copyCodeToClipboard = React.useCallback(() => {
+        clipboardService.writeText(code);
+    }, [code, clipboardService]);
+    return <button onClick={copyCodeToClipboard}>Copy</button>;
+};
+
+const InsertCodeAtCursorButton = (props: { code: string, editorManager: EditorManager }) => {
+    const { code, editorManager } = props;
+    const insertCode = React.useCallback(() => {
+        const editor = editorManager.currentEditor;
+        if (editor) {
+            const currentEditor = editor.editor;
+            const selection = currentEditor.selection;
+
+            // Insert the text at the current cursor position
+            // If there is a selection, replace the selection with the text
+            currentEditor.executeEdits([{
+                range: {
+                    start: selection.start,
+                    end: selection.end
+                },
+                newText: code
+            }]);
+        }
+    }, [code, editorManager]);
+    return <button onClick={insertCode}>Insert at Cursor</button>;
+};
 
 /**
  * Renders the given code within a Monaco Editor

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatResponsePartRenderer } from '../types';
+import { injectable } from '@theia/core/shared/inversify';
+import { ChatResponseContent, isCodeChatResponseContent, CodeChatResponseContent } from '@theia/ai-chat/lib/common';
+import { ReactNode } from '@theia/core/shared/react';
+import * as React from '@theia/core/shared/react';
+
+@injectable()
+export class CodePartRenderer implements ChatResponsePartRenderer<CodeChatResponseContent> {
+    canHandle(response: ChatResponseContent): number {
+        if (isCodeChatResponseContent(response)) {
+            return 10;
+        }
+        return -1;
+    }
+    render(response: CodeChatResponseContent): ReactNode {
+        return <div>{JSON.stringify(response)}</div>;
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -19,6 +19,9 @@ import { injectable } from '@theia/core/shared/inversify';
 import { ChatResponseContent, isCodeChatResponseContent, CodeChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ReactNode } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github.css';
+import * as DOMPurify from '@theia/core/shared/dompurify';
 
 @injectable()
 export class CodePartRenderer implements ChatResponsePartRenderer<CodeChatResponseContent> {
@@ -29,6 +32,13 @@ export class CodePartRenderer implements ChatResponsePartRenderer<CodeChatRespon
         return -1;
     }
     render(response: CodeChatResponseContent): ReactNode {
-        return <div>{JSON.stringify(response)}</div>;
+        const highlightedCode = hljs.highlight(response.code, { language: response.language }).value;
+
+        return (
+            <pre>
+                <code dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(highlightedCode) }}>
+                </code>
+            </pre>
+        );
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -156,7 +156,9 @@ export const CodeWrapper = (props: {
             readOnly: true,
             autoSizing: true,
             maxHeight: undefined,
-            codeLens: false
+            codeLens: false,
+            inlayHints: { enabled: 'off' },
+            hover: { enabled: false }
         });
         editor.document.textEditorModel.setValue(props.content);
         editorRef.current = editor;

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -147,7 +147,8 @@ export const CodeWrapper = (props: {
         const editor = await props.editorProvider.createInline(resource.uri, ref.current!, {
             readOnly: true,
             autoSizing: true,
-            maxHeight: undefined
+            maxHeight: undefined,
+            codeLens: false
         });
         editor.document.textEditorModel.setValue(props.content);
         editorRef.current = editor;

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
@@ -13,5 +13,6 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+export * from './code-part-renderer';
 export * from './text-part-renderer';
 export * from './markdown-part-renderer';

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -134,3 +134,32 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInputOptions .option:hover {
     opacity: 1;
 }
+
+.theia-CodePartRenderer-root {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.theia-CodePartRenderer-left {
+    flex-grow: 1;
+}
+
+.theia-CodePartRenderer-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 4px;
+}
+
+.theia-CodePartRenderer-right button {
+    margin-left: 4px;
+}
+
+.theia-CodePartRenderer-separator {
+    width: 100%;
+    height: 1px;
+    background-color: #ccc;
+}

--- a/packages/ai-chat-ui/tsconfig.json
+++ b/packages/ai-chat-ui/tsconfig.json
@@ -16,7 +16,13 @@
       "path": "../core"
     },
     {
+      "path": "../editor"
+    },
+    {
       "path": "../filesystem"
+    },
+    {
+      "path": "../monaco"
     },
     {
       "path": "../workspace"

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -18,6 +18,7 @@ import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent, DefaultChatAgent } from '../common';
+import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -30,5 +31,6 @@ export default new ContainerModule(bind => {
 
     bind(DefaultChatAgent).toSelf().inSingletonScope();
     bind(Agent).toService(DefaultChatAgent);
-    bind(ChatAgent).toService(DefaultChatAgent);
+    // bind(ChatAgent).toService(DefaultChatAgent);
+    bind(ChatAgent).toService(MockCodeChatAgent);
 });

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -21,8 +21,13 @@ import {
     ChatAgent, ChatAgentService,
     ChatAgentServiceImpl,
     ChatRequestParser,
-    ChatRequestParserImpl, ChatService, ChatServiceImpl, ChatVariablesService, DefaultChatAgent, DummyChatVariablesService
-    DummyChatAgent,
+    ChatRequestParserImpl,
+    ChatService,
+    ChatServiceImpl,
+    ChatVariablesService,
+    DefaultChatAgent,
+    DummyChatVariablesService,
+    DummyChatAgent
 } from '../common';
 import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 import { DummyCommandContribution } from './dummy-command-contribution';

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -18,6 +18,7 @@ import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { AgentDispatcher, AgentDispatcherImpl, ChatAgent, ChatService, ChatServiceImpl, DefaultChatAgent } from '../common';
+import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -31,4 +32,7 @@ export default new ContainerModule(bind => {
     bind(DefaultChatAgent).toSelf().inSingletonScope();
     bind(Agent).toService(DefaultChatAgent);
     bind(ChatAgent).toService(DefaultChatAgent);
+
+    bind(MockCodeChatAgent).toSelf().inSingletonScope();
+    bind(ChatAgent).toService(MockCodeChatAgent);
 });

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -17,7 +17,7 @@
 import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent, DefaultChatAgent } from '../common';
+import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent } from '../common';
 import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 
 export default new ContainerModule(bind => {
@@ -29,8 +29,10 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    bind(DefaultChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(DefaultChatAgent);
+    // bind(DefaultChatAgent).toSelf().inSingletonScope();
+    // bind(Agent).toService(DefaultChatAgent);
     // bind(ChatAgent).toService(DefaultChatAgent);
+    bind(MockCodeChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(MockCodeChatAgent);
     bind(ChatAgent).toService(MockCodeChatAgent);
 });

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -17,8 +17,7 @@
 import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent } from '../common';
-import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
+import { AgentDispatcher, AgentDispatcherImpl, ChatAgent, ChatService, ChatServiceImpl, DefaultChatAgent } from '../common';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -29,10 +28,7 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    // bind(DefaultChatAgent).toSelf().inSingletonScope();
-    // bind(Agent).toService(DefaultChatAgent);
-    // bind(ChatAgent).toService(DefaultChatAgent);
-    bind(MockCodeChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(MockCodeChatAgent);
-    bind(ChatAgent).toService(MockCodeChatAgent);
+    bind(DefaultChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(DefaultChatAgent);
+    bind(ChatAgent).toService(DefaultChatAgent);
 });

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -331,11 +331,11 @@ export class CodeChatResponseContentImpl implements CodeChatResponseContent {
     }
 
     merge(nextChatResponseContent: CodeChatResponseContent): boolean {
-        if (this._language === nextChatResponseContent.language) {
-            this._code += `\n${nextChatResponseContent.code}`;
-            return true;
-        }
-        return false;
+        console.log("Merge CURRENT", this._code);
+        this._code += `${nextChatResponseContent.code}`;
+        console.log("MERGE NEXT", nextChatResponseContent.code);
+        console.log("MERGE NEW", this._code);
+        return true;
     }
 }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -115,7 +115,7 @@ export interface CodeChatResponseContent
     extends BaseChatResponseContent {
     kind: 'code';
     code: string;
-    language: string;
+    language?: string;
     location?: Location;
 }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -327,14 +327,11 @@ export class CodeChatResponseContentImpl implements CodeChatResponseContent {
     }
 
     asString(): string {
-        return `\`\`\`${this._language}\n${this._code}\n\`\`\``;
+        return `\`\`\`${this._language ?? ''}\n${this._code}\n\`\`\``;
     }
 
     merge(nextChatResponseContent: CodeChatResponseContent): boolean {
-        console.log("Merge CURRENT", this._code);
         this._code += `${nextChatResponseContent.code}`;
-        console.log("MERGE NEXT", nextChatResponseContent.code);
-        console.log("MERGE NEW", this._code);
         return true;
     }
 }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -166,10 +166,7 @@ export const isCodeChatResponseContent = (
     isBaseChatResponseContent(obj) &&
     obj.kind === 'code' &&
     'code' in obj &&
-    typeof (obj as { code: unknown }).code === 'string'
-    && 'language' in obj
-    && typeof (obj as { language: unknown }).language === 'string'
-    && 'location' in obj && isLocation((obj as { location: unknown }).location);
+    typeof (obj as { code: unknown }).code === 'string';
 
 export type ChatResponseContent =
     | BaseChatResponseContent

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -19,7 +19,8 @@
  *--------------------------------------------------------------------------------------------*/
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatModel.ts
 
-import { Command, Emitter, Event, generateUuid } from '@theia/core';
+import { Command, Emitter, Event, generateUuid, URI } from '@theia/core';
+import { Position } from '@theia/core/shared/vscode-languageserver-protocol';
 import { MarkdownString, MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 
 /**********************
@@ -115,7 +116,17 @@ export interface CodeChatResponseContent
     kind: 'code';
     code: string;
     language: string;
-    location?: string;
+    location?: Location;
+}
+
+export interface Location {
+    uri: URI;
+    position: Position;
+}
+export function isLocation(obj: unknown): obj is Location {
+    return !!obj && typeof obj === 'object' &&
+        'uri' in obj && obj.uri instanceof URI &&
+        'position' in obj && Position.is(obj.position);
 }
 
 export interface CommandChatResponseContent
@@ -157,7 +168,8 @@ export const isCodeChatResponseContent = (
     'code' in obj &&
     typeof (obj as { code: unknown }).code === 'string'
     && 'language' in obj
-    && typeof (obj as { language: unknown }).language === 'string';
+    && typeof (obj as { language: unknown }).language === 'string'
+    && 'location' in obj && isLocation(obj.location);
 
 export type ChatResponseContent =
     | BaseChatResponseContent

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -110,6 +110,14 @@ export interface MarkdownChatResponseContent
     content: MarkdownString;
 }
 
+export interface CodeChatResponseContent
+    extends BaseChatResponseContent {
+    kind: 'code';
+    code: string;
+    language: string;
+    location?: string;
+}
+
 export interface CommandChatResponseContent
     extends BaseChatResponseContent {
     kind: 'command';
@@ -141,11 +149,22 @@ export const isCommandChatResponseContent = (
     'command' in obj &&
     Command.is((obj as { command: unknown }).command);
 
+export const isCodeChatResponseContent = (
+    obj: unknown
+): obj is CodeChatResponseContent =>
+    isBaseChatResponseContent(obj) &&
+    obj.kind === 'code' &&
+    'code' in obj &&
+    typeof (obj as { code: unknown }).code === 'string'
+    && 'language' in obj
+    && typeof (obj as { language: unknown }).language === 'string';
+
 export type ChatResponseContent =
     | BaseChatResponseContent
     | TextChatResponseContent
     | MarkdownChatResponseContent
-    | CommandChatResponseContent;
+    | CommandChatResponseContent
+    | CodeChatResponseContent;
 
 export interface ChatResponse {
     readonly content: ChatResponseContent[];

--- a/packages/ai-chat/src/common/mock-code-chat-agent.ts
+++ b/packages/ai-chat/src/common/mock-code-chat-agent.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ChatAgent } from './chat-agents';
+import { ILogger } from '@theia/core';
+import { LanguageModelSelector, PromptTemplate } from '@theia/ai-core';
+import { ChatRequestModelImpl, CodeChatResponseContentImpl } from './chat-model';
+
+const CODE_SNIPPET: string = `
+/**
+ * Calculates the factorial of a given number.
+ * @param n - The number to calculate the factorial for.
+ * @returns The factorial of the number.
+ */
+function factorial(n: number): number {
+    // Base case: if n is 0 or 1, return 1
+    if (n === 0 || n === 1) {
+        return 1;
+    }
+
+    // Recursive case: n * factorial of (n - 1)
+    return n * factorial(n - 1);
+}
+`;
+
+const CODE_SNIPPET_LANGUAGE = 'typescript';
+
+@injectable()
+export class MockCodeChatAgent implements ChatAgent {
+
+    @inject(ILogger)
+    protected logger: ILogger;
+
+    defaultImplicitVariables?: string[] | undefined;
+    id: string = 'MockCodeChatAgent';
+    name: string = 'Mock Code Chat Agent';
+    description: string = 'Mock agent to test code response parts Theia.';
+    variables: string[] = [];
+    promptTemplates: PromptTemplate[] = [];
+    languageModelRequirements: Omit<LanguageModelSelector, 'agentId'>[] = [];
+
+    async invoke(request: ChatRequestModelImpl): Promise<void> {
+        request.response.response.addContent(new CodeChatResponseContentImpl(CODE_SNIPPET, CODE_SNIPPET_LANGUAGE));
+        request.response.complete();
+    }
+
+}

--- a/packages/ai-chat/src/common/mock-code-chat-agent.ts
+++ b/packages/ai-chat/src/common/mock-code-chat-agent.ts
@@ -15,9 +15,9 @@
 // *****************************************************************************
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatAgent } from './chat-agents';
-import { ILogger } from '@theia/core';
+import { ILogger, URI } from '@theia/core';
 import { LanguageModelSelector, PromptTemplate } from '@theia/ai-core';
-import { ChatRequestModelImpl, CodeChatResponseContentImpl } from './chat-model';
+import { ChatRequestModelImpl, CodeChatResponseContentImpl, Location } from './chat-model';
 
 const CODE_SNIPPET: string = `
 /**
@@ -53,7 +53,16 @@ export class MockCodeChatAgent implements ChatAgent {
     languageModelRequirements: Omit<LanguageModelSelector, 'agentId'>[] = [];
 
     async invoke(request: ChatRequestModelImpl): Promise<void> {
-        request.response.response.addContent(new CodeChatResponseContentImpl(CODE_SNIPPET, CODE_SNIPPET_LANGUAGE));
+        const dummyLocation: Location = {
+            // FIXME Add real uri for testing
+            uri: new URI('/home/user/workspace/test/myfile.ts'),
+            position: {
+                line: 2,
+                character: 5
+            }
+        };
+
+        request.response.response.addContent(new CodeChatResponseContentImpl(CODE_SNIPPET, CODE_SNIPPET_LANGUAGE, dummyLocation));
         request.response.complete();
     }
 

--- a/packages/ai-chat/src/node/agent-backend-module.ts
+++ b/packages/ai-chat/src/node/agent-backend-module.ts
@@ -17,7 +17,8 @@
 import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, DefaultChatAgent, ChatAgent  } from '../common';
+import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent  } from '../common';
+import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -29,7 +30,10 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    bind(DefaultChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(DefaultChatAgent);
-    bind(ChatAgent).toService(DefaultChatAgent);
+    // bind(DefaultChatAgent).toSelf().inSingletonScope();
+    // bind(Agent).toService(DefaultChatAgent);
+    // bind(ChatAgent).toService(DefaultChatAgent);
+    bind(MockCodeChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(MockCodeChatAgent);
+    bind(ChatAgent).toService(MockCodeChatAgent);
 });

--- a/packages/ai-chat/src/node/agent-backend-module.ts
+++ b/packages/ai-chat/src/node/agent-backend-module.ts
@@ -18,6 +18,7 @@ import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { AgentDispatcher, AgentDispatcherImpl, ChatAgent, ChatService, ChatServiceImpl, DefaultChatAgent } from '../common';
+import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -33,6 +34,6 @@ export default new ContainerModule(bind => {
     bind(Agent).toService(DefaultChatAgent);
     bind(ChatAgent).toService(DefaultChatAgent);
 
-
-
+    bind(MockCodeChatAgent).toSelf().inSingletonScope();
+    bind(ChatAgent).toService(MockCodeChatAgent);
 });

--- a/packages/ai-chat/src/node/agent-backend-module.ts
+++ b/packages/ai-chat/src/node/agent-backend-module.ts
@@ -17,8 +17,7 @@
 import { Agent } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { AgentDispatcher, AgentDispatcherImpl, ChatService, ChatServiceImpl, ChatAgent  } from '../common';
-import { MockCodeChatAgent } from '../common/mock-code-chat-agent';
+import { AgentDispatcher, AgentDispatcherImpl, ChatAgent, ChatService, ChatServiceImpl, DefaultChatAgent } from '../common';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -30,10 +29,10 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    // bind(DefaultChatAgent).toSelf().inSingletonScope();
-    // bind(Agent).toService(DefaultChatAgent);
-    // bind(ChatAgent).toService(DefaultChatAgent);
-    bind(MockCodeChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(MockCodeChatAgent);
-    bind(ChatAgent).toService(MockCodeChatAgent);
+    bind(DefaultChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(DefaultChatAgent);
+    bind(ChatAgent).toService(DefaultChatAgent);
+
+
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,6 +6441,11 @@ highlight.js@10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
+highlight.js@^11.10.0:
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.10.0.tgz#6e3600dc4b33d6dc23d5bd94fbf72405f5892b92"
+  integrity sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,11 +6441,6 @@ highlight.js@10.4.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
-highlight.js@^11.10.0:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.10.0.tgz#6e3600dc4b33d6dc23d5bd94fbf72405f5892b92"
-  integrity sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==
-
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Close https://github.com/eclipsesource/osweek-2024/issues/19
Part of https://github.com/eclipsesource/osweek-2024/issues/54

Adds a renderer for a code block using the monaco editor.

![image](https://github.com/user-attachments/assets/4c77ed4a-59f1-445b-b9e4-0761a5932a75)

Implements:
- Copy
- Insert at cursor
- Monaco Editor
- Navigating to the location of the file (if provided)

The parser needs improvement.

#### How to test

0. Install the TypeScript Extension for Theia (for syntax highlighting)
1. packages/ai-chat/src/common/mock-code-chat-agent.ts Replace the URI.
2. Send a message to the bot
3. Click on the buttons / see highlighted code

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
