### PR TITLE
Review and adapt prompt templates

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -75,13 +75,7 @@ export class DefaultChatAgent implements ChatAgent {
     name: string = 'Default Chat Agent';
     description: string = 'The default chat agent provided by Theia.';
     variables: string[] = [];
-    promptTemplates: PromptTemplate[] = [{
-        id: 'test-template',
-        template: 'Hello, ${name}! This is just a mock template. Nothing useful here.',
-    }, {
-        id: 'mock-template',
-        template: 'Hello, ${name}! This is just another mock template. Nothing useful here either.',
-    }];
+    promptTemplates: PromptTemplate[] = [];
     // FIXME: placeholder values
     languageModelRequirements: Omit<LanguageModelSelector, 'agent'>[] = [{
         purpose: 'chat',

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -28,8 +28,8 @@ import {
     languageModelDelegatePath,
     languageModelRegistryDelegatePath,
     PromptService,
-    PromptServiceImpl,
-    PromptCustomizationService
+    PromptCustomizationService,
+    PromptServiceImpl
 } from '../common';
 import {
     FrontendLanguageModelRegistryImpl,

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -14,11 +14,14 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { PromptCustomizationService } from '../common';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { Agent, PromptCustomizationService, PromptTemplate } from '../common';
 import { PromptPreferences } from './prompt-preferences';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { URI } from '@theia/core';
+import { ContributionProvider, DisposableCollection, URI } from '@theia/core';
+import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { OpenerService } from '@theia/core/lib/browser';
 
 @injectable()
 export class FrontendPromptCustomizationServiceImpl implements PromptCustomizationService {
@@ -29,7 +32,16 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
     @inject(FileService)
     protected readonly fileService: FileService;
 
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
+
+    @inject(ContributionProvider) @named(Agent)
+    protected readonly agents: ContributionProvider<Agent>;
+
+    protected readonly trackedTemplateURIs = new Set<string>();
     protected readonly templates = new Map<string, string>();
+
+    protected toDispose = new DisposableCollection();
 
     @postConstruct()
     protected init(): void {
@@ -42,21 +54,63 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
     }
 
     protected async update(): Promise<void> {
+        this.toDispose.dispose();
         this.templates.clear();
+        this.trackedTemplateURIs.clear();
+
         const templateFolder = this.preferences['ai-chat.templates-folder'];
         if (templateFolder === undefined || templateFolder.trim().length === 0) {
             return;
         }
-        const stat = await this.fileService.resolve(URI.fromFilePath(templateFolder));
+        const templateURI = URI.fromFilePath(templateFolder);
+
+        this.toDispose.push(this.fileService.watch(templateURI, { recursive: true, excludes: [] }));
+        this.toDispose.push(this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
+
+            for (const child of this.trackedTemplateURIs) {
+                // check deletion and updates
+                if (event.contains(new URI(child))) {
+                    for (const deletedFile of event.getDeleted()) {
+                        if (this.trackedTemplateURIs.has(deletedFile.resource.toString())) {
+                            this.trackedTemplateURIs.delete(deletedFile.resource.toString());
+                            this.templates.delete(deletedFile.resource.path.name);
+                        }
+                    }
+                    for (const updatedFile of event.getUpdated()) {
+                        if (this.trackedTemplateURIs.has(updatedFile.resource.toString())) {
+                            const filecontent = await this.fileService.read(updatedFile.resource);
+                            this.templates.set(this.removePromptTemplateSuffix(updatedFile.resource.path.name), filecontent.value);
+                        }
+                    }
+                }
+            }
+
+            // check new templates
+            for (const addedFile of event.getAdded()) {
+                if (addedFile.resource.parent.toString() === templateURI.toString() && addedFile.resource.path.ext === '.prompttemplate') {
+                    this.trackedTemplateURIs.add(addedFile.resource.toString());
+                    const filecontent = await this.fileService.read(addedFile.resource);
+                    this.templates.set(this.removePromptTemplateSuffix(addedFile.resource.path.name), filecontent.value);
+                }
+            }
+
+        }));
+
+        const stat = await this.fileService.resolve(templateURI);
         if (stat.children === undefined) {
             return;
         }
+
         for (const file of stat.children) {
             if (!file.isFile) {
                 continue;
             }
-            const filecontent = await this.fileService.read(file.resource);
-            this.templates.set(this.removePromptTemplateSuffix(file.name), filecontent.value);
+            const fileURI = file.resource;
+            if (fileURI.path.ext === '.prompttemplate') {
+                this.trackedTemplateURIs.add(fileURI.toString());
+                const filecontent = await this.fileService.read(fileURI);
+                this.templates.set(this.removePromptTemplateSuffix(file.name), filecontent.value);
+            }
         }
     }
 
@@ -75,4 +129,49 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
     getCustomizedPromptTemplate(id: string): string | undefined {
         return this.templates.get(id);
     }
+
+    async editTemplate(id: string, content?: string): Promise<void> {
+        const template = this.getTemplate(id);
+        if (template === undefined) {
+            throw new Error(`Unable to edit template ${id}: template not found.`);
+        }
+        const templatesFolder = this.preferences['ai-chat.templates-folder'];
+        const editorUri = new URI(`file://${templatesFolder}/${id}.prompttemplate`);
+        if (! await this.fileService.exists(editorUri)) {
+            await this.fileService.createFile(editorUri, BinaryBuffer.fromString(content ?? template.template));
+        } else if (content) {
+            // Write content to the file before opening it
+            await this.fileService.writeFile(editorUri, BinaryBuffer.fromString(content));
+        }
+        const openHandler = await this.openerService.getOpener(editorUri);
+        openHandler.open(editorUri);
+    }
+
+    async resetTemplate(id: string): Promise<void> {
+        const templatesFolder = this.preferences['ai-chat.templates-folder'];
+        const editorUri = new URI(`file://${templatesFolder}/${id}.prompttemplate`);
+        if (await this.fileService.exists(editorUri)) {
+            await this.fileService.delete(editorUri);
+        }
+    }
+
+    getTemplate(id: string): PromptTemplate | undefined {
+        for (const agent of this.agents.getContributions()) {
+            for (const template of agent.promptTemplates) {
+                if (template.id === id) {
+                    return template;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    getTemplateIDFromURI(uri: URI): string | undefined {
+        const id = this.removePromptTemplateSuffix(uri.path.name);
+        if (this.templates.has(id)) {
+            return id;
+        }
+        return undefined;
+    }
+
 }

--- a/packages/ai-core/src/browser/style/index.css
+++ b/packages/ai-core/src/browser/style/index.css
@@ -9,3 +9,11 @@
 .language-model-container .theia-select {
   margin-left: var(--theia-ui-padding);
 }
+
+.ai-templates {
+  display: grid;
+  /** Display content in 3 columns */
+  grid-template-columns: 1fr auto auto;
+  /** add a 3px gap between rows */
+  row-gap: 3px;
+}

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { URI } from '@theia/core';
 import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { PromptTemplate } from './types';
 
@@ -26,6 +27,11 @@ export interface PromptService {
      * @param id the id of the {@link PromptTemplate}
      */
     getRawPrompt(id: string): PromptTemplate | undefined;
+    /**
+     * Retrieve the default raw {@link PromptTemplate} object.
+     * @param id the id of the {@link PromptTemplate}
+     */
+    getDefaultRawPrompt(id: string): PromptTemplate | undefined;
     /**
      * Allows to directly replace placeholders in the prompt. The supported format is 'Hi ${name}!'.
      * The placeholder is then searched inside the args object and replaced.
@@ -58,6 +64,28 @@ export interface PromptCustomizationService {
      * @param id the id of the {@link PromptTemplate} to check
      */
     getCustomizedPromptTemplate(id: string): string | undefined
+
+    /**
+     * Edit the template. If the content is specified, is will be
+     * used to customize the template. Otherwise, the behavior depends
+     * on the implementation. Implementation may for example decide to
+     * open an editor, or request more information from the user, ...
+     * @param id the template id.
+     * @param content optional content to customize the template.
+     */
+    editTemplate(id: string, content?: string): void;
+
+    /**
+     * Reset the template to its default value.
+     * @param id the template id.
+     */
+    resetTemplate(id: string): void;
+
+    /**
+     * Return the template id for a given template file.
+     * @param uri the uri of the template file
+     */
+    getTemplateIDFromURI(uri: URI): string | undefined;
 }
 
 @injectable()
@@ -75,6 +103,9 @@ export class PromptServiceImpl implements PromptService {
                 return { id, template };
             }
         }
+        return this.getDefaultRawPrompt(id);
+    }
+    getDefaultRawPrompt(id: string): PromptTemplate | undefined {
         return this._prompts[id];
     }
     getPrompt(id: string, args?: { [key: string]: unknown }): string | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

Issue: https://github.com/eclipsesource/osweek-2024/issues/38

#### What it does

- add a preference to configure a 'prompt templates' folder used to hold custom templates
- contribute templates to the AI Settings view, with actions to edit and reset custom templates
- add an editor for prompt templates
- add a (test) command to check custom templates

#### How to test

- define the prompt templates folder in the Theia Preferences, or use the default one `$HOME/.theia/prompt-templates`
  - users can choose a custom folder to do some version control
  - if the folder is part of the workspace, it can be shared between project contributors
- open the AI Settings view and click "Edit" on any available template
- edit the template
  - check syntax highlighting and auto closing brackets when typing `${`
- run the `Theia AI Prompt Templates: Show all prompts` test command
  - it should display custom templates
- in the template editor, pressing the "discard" button will restore the default template content
- in the AI Settings view, resetting the template removes the entire file