### PR TITLE
 Select language models for agents

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -78,11 +78,25 @@ export class DefaultChatAgent implements ChatAgent {
         id: 'mock-template',
         template: 'Hello, ${name}! This is just another mock template. Nothing useful here either.',
     }];
-    languageModelRequirements: Omit<LanguageModelSelector, 'agentId'>[] = [];
+    // FIXME: placeholder values
+    languageModelRequirements: Omit<LanguageModelSelector, 'agent'>[] = [{
+        purpose: 'chat',
+        identifier: 'openai/gpt-4o',
+    },
+    {
+        purpose: 'autocomplete',
+        name: 'default-autocomplete-model',
+        version: '0.0.1',
+        family: 'default-family',
+        tokens: 256,
+        identifier: 'default-identifier',
+        vendor: 'default-vendor'
+    }];
     locations: ChatAgentLocation[] = [];
 
     async invoke(request: ChatRequestModelImpl): Promise<void> {
-        const languageModels = await this.languageModelRegistry.getLanguageModels();
+        const selector = this.languageModelRequirements.find(req => req.purpose === 'chat')!;
+        const languageModels = await this.languageModelRegistry.selectLanguageModels({ agent: this.id, ...selector });
         if (languageModels.length === 0) {
             throw new Error('Couldn\'t find a language model. Please check your setup!');
         }

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -45,6 +45,7 @@ import { FrontendPromptCustomizationServiceImpl } from './frontend-prompt-custom
 import { AISettingsWidget } from './ai-settings-widget';
 import { AISettingsViewContribution } from './ai-settings-view-contribution';
 import { AICoreFrontendApplicationContribution } from './ai-core-frontend-application-contribution';
+import { AISettingsService } from './ai-settings-service';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -82,7 +83,7 @@ export default new ContainerModule(bind => {
     bind(CommandContribution).toService(PromptTemplateContribution);
     bind(TabBarToolbarContribution).toService(PromptTemplateContribution);
 
-    bind(AISettingsWidget).toSelf().inSingletonScope();
+    bind(AISettingsWidget).toSelf();
     bind(WidgetFactory)
         .toDynamicValue(ctx => ({
             id: AISettingsWidget.ID,
@@ -91,6 +92,6 @@ export default new ContainerModule(bind => {
         .inSingletonScope();
 
     bindViewContribution(bind, AISettingsViewContribution);
-
+ 	bind(AISettingsService).toSelf().inRequestScope();
     bind(FrontendApplicationContribution).to(AICoreFrontendApplicationContribution).inSingletonScope();
 });

--- a/packages/ai-core/src/browser/ai-settings-service.ts
+++ b/packages/ai-core/src/browser/ai-settings-service.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { DisposableCollection } from '@theia/core';
+import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
+import { JSONObject } from '@theia/core/shared/@phosphor/coreutils';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { LanguageModelSelector } from '../common';
+
+@injectable()
+export class AISettingsService {
+    @inject(PreferenceService) protected preferenceService: PreferenceService;
+    static readonly PREFERENCE_NAME = 'ai.settings';
+
+    protected toDispose = new DisposableCollection();
+
+    updateAgentSettings(agent: string, agentSettings: AgentSettings): void {
+        const settings = this.getSettings();
+        settings.agents[agent] = agentSettings;
+        this.preferenceService.set(AISettingsService.PREFERENCE_NAME, settings, PreferenceScope.User);
+    }
+
+    getAgentSettings(agent: string): AgentSettings | undefined {
+        const settings = this.getSettings();
+        return settings.agents[agent];
+    }
+
+    getSettings(): AISettings {
+        const pref = this.preferenceService.inspect<AISettings>(AISettingsService.PREFERENCE_NAME);
+        return pref?.value ? pref.value : { agents: {} };
+    }
+
+}
+export interface AISettings extends JSONObject {
+    agents: Record<string, AgentSettings>
+}
+
+interface AgentSettings extends JSONObject {
+    languageModelRequirements: Omit<LanguageModelSelector, 'agent'>[];
+}

--- a/packages/ai-core/src/browser/ai-settings-widget.tsx
+++ b/packages/ai-core/src/browser/ai-settings-widget.tsx
@@ -14,14 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ContributionProvider, nls } from '@theia/core';
-import { codicon, Panel, ReactWidget, StatefulWidget } from '@theia/core/lib/browser';
+import { ContributionProvider, ILogger, nls } from '@theia/core';
+import { codicon, Panel, ReactWidget } from '@theia/core/lib/browser';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
-import { Agent, PromptTemplate } from '../common/';
+import { Agent, LanguageModel, LanguageModelRegistry, PromptTemplate } from '../common/';
 import * as React from '@theia/core/shared/react';
+import { AISettingsService } from './ai-settings-service';
+import '../../src/browser/style/index.css';
 
 @injectable()
-export class AISettingsWidget extends ReactWidget implements StatefulWidget {
+export class AISettingsWidget extends ReactWidget {
 
     static readonly ID = 'ai_settings_widget';
     static readonly LABEL = nls.localizeByDefault('AI Settings');
@@ -31,39 +33,113 @@ export class AISettingsWidget extends ReactWidget implements StatefulWidget {
     @inject(ContributionProvider) @named(Agent)
     protected readonly agents: ContributionProvider<Agent>;
 
+    @inject(LanguageModelRegistry)
+    protected readonly languageModelRegistry: LanguageModelRegistry;
+
+    @inject(AISettingsService)
+    protected readonly aiSettingsService: AISettingsService;
+
+    @inject(ILogger)
+    protected logger: ILogger;
+
+    protected languageModels: LanguageModel[] | undefined;
+
+    // map from agent id to selected purpose
+    protected selectedPurposes: Map<string, string> = new Map();
+    // map from agent id to selected purpose and model
+    protected selectedModels: Map<string, Map<string, LanguageModel>> = new Map();
 
     @postConstruct()
     protected init(): void {
         this.id = AISettingsWidget.ID;
         this.title.label = AISettingsWidget.LABEL;
         this.title.closable = true;
-        this.addClass('theia-settings-container');
+        this.addClass('theia-ai-settings-container');
         this.title.iconClass = codicon('hubot');
+
+        this.languageModelRegistry.getLanguageModels().then(models => {
+            this.languageModels = models ?? [];
+            this.update();
+        });
 
         this.update();
     }
+    private onSelectedPurposesChange(agentId: string, event: React.ChangeEvent<HTMLSelectElement>): void {
+        this.selectedPurposes.set(agentId, event.target.value);
+        this.update();
+    };
+
+    private onSelectedModelChange(agentId: string, event: React.ChangeEvent<HTMLSelectElement>): void {
+        const selectedPurpose = this.selectedPurposes.get(agentId);
+        if (!selectedPurpose) {
+            console.error('No purpose selected');
+            return;
+        }
+        const selectedModel = this.languageModels?.find(model => model.id === event.target.value);
+        if (!selectedModel) {
+            console.error('Could not find language model with id', event.target.value);
+            return;
+        }
+        if (this.selectedModels.get(agentId) === undefined) {
+            this.selectedModels.set(agentId, new Map());
+        }
+        this.selectedModels.get(agentId)!.set(selectedPurpose, selectedModel);
+        this.aiSettingsService.updateAgentSettings(agentId, { languageModelRequirements: [{ purpose: selectedPurpose, identifier: selectedModel.id }] });
+        this.update();
+    };
 
     protected render(): React.ReactNode {
         return (
-            <div>
-                {this.renderAgentSettings()}
+            <div key={AISettingsWidget.ID}>
+                {this.agents.getContributions().map(agent =>
+                    <div key={agent.id}>
+                        <h2>{agent.name}</h2>
+                        <AgentTemplates agent={agent} key={agent.id} />
+                        <div className='language-model-container'>
+                            <label className="theia-header no-select" htmlFor={`purpose-select-${agent.id}`}>Purpose:</label>
+                            <select
+                                className="theia-select"
+                                id={`purpose-select-${agent.id}`}
+                                value={this.selectedPurposes.get(agent.id)}
+                                onChange={event => this.onSelectedPurposesChange(agent.id, event)}
+                            >
+                                <option value=""></option>
+                                {agent.languageModelRequirements.map((requirements, index) => (
+                                    <option key={index} value={requirements.purpose}>{requirements.purpose}</option>
+                                ))}
+                            </select>
+                            {agent.languageModelRequirements
+                                .filter(requirements => requirements.purpose === this.selectedPurposes.get(agent.id))
+                                .map((requirements, index) => <div key={index}>
+                                    {requirements.identifier && <p><strong>Identifier: </strong> {requirements.identifier}</p>}
+                                    {requirements.name && <p><strong>Name: </strong> {requirements.name}</p>}
+                                    {requirements.vendor && <p><strong>Vendor: </strong> {requirements.vendor}</p>}
+                                    {requirements.version && <p><strong>Version: </strong> {requirements.version}</p>}
+                                    {requirements.family && <p><strong>Family: </strong> {requirements.family}</p>}
+                                    {requirements.tokens && <p><strong>Tokens: </strong> {requirements.tokens}</p>}
+                                </div>)
+                            }
+                            {this.selectedPurposes.get(agent.id) &&
+                                <>
+                                    <label className="theia-header no-select" htmlFor={`model-select-${agent.id}`}>Language Model:</label>
+                                    <select
+                                        className="theia-select"
+                                        id={`model-select-${agent.id}`}
+                                        value={this.selectedModels?.get(agent.id)?.get(this.selectedPurposes.get(agent.id)!)?.id}
+                                        onChange={event => this.onSelectedModelChange(agent.id, event)}
+                                    >
+                                        <option value=""></option>
+                                        {this.languageModels?.map((model, index) => (
+                                            <option key={index} value={model.id}>{model.name ?? model.id}</option>
+                                        ))}
+                                    </select>
+                                </>
+                            }
+                        </div>
+                    </div>)
+                }
             </div >
         );
-    }
-
-    protected renderAgentSettings(): React.ReactNode {
-        return this.agents.getContributions().map(agent => (
-            <AgentSettings agent={agent} key={agent.id} />
-        ));
-    }
-
-    storeState(): object | undefined {
-        // Implement the logic to store the state of the widget
-        return {};
-    }
-
-    restoreState(oldState: object): void {
-        // Implement the logic to restore the state of the widget
     }
 }
 
@@ -71,8 +147,7 @@ interface AgentProps {
     agent: Agent;
 }
 
-const AgentSettings: React.FC<AgentProps> = ({ agent }) => <div>
-    <h2>{agent.name}</h2>
+const AgentTemplates: React.FC<AgentProps> = ({ agent }) => <div>
     {agent.promptTemplates.map(template => <TemplateSetting agentId={agent.id} template={template} key={agent.id + '.' + template.id} />)}
 </div>;
 

--- a/packages/ai-core/src/browser/style/index.css
+++ b/packages/ai-core/src/browser/style/index.css
@@ -1,0 +1,11 @@
+.theia-ai-settings-container {
+  padding: var(--theia-ui-padding);
+}
+
+.language-model-container {
+  padding-top: calc(2 * var(--theia-ui-padding));
+}
+
+.language-model-container .theia-select {
+  margin-left: var(--theia-ui-padding);
+}

--- a/packages/ai-core/src/common/agent.ts
+++ b/packages/ai-core/src/common/agent.ts
@@ -35,5 +35,5 @@ export interface Agent {
     readonly promptTemplates: PromptTemplate[];
 
     /** Required language models. This includes the purpose and optional language model selector arguments. See #47. */
-    readonly languageModelRequirements: Omit<LanguageModelSelector, 'agentId'>[];
+    readonly languageModelRequirements: Omit<LanguageModelSelector, 'agent'>[];
 }

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -104,7 +104,7 @@ interface VsCodeLanguageModelSelector {
 }
 
 export interface LanguageModelSelector extends VsCodeLanguageModelSelector {
-    readonly actor: string;
+    readonly agent: string;
     readonly purpose: string;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

Issue: https://github.com/eclipsesource/osweek-2024/issues/42

Follow-up with known issues and improvements: https://github.com/eclipsesource/osweek-2024/issues/59

#### What it does
- Add section for re-configuring agent purposes ( i.e language model for a specific purpose)
- Introduce AISettingService service to retrieve and configure AI settings for a specific agent.
- Use Theia preferences as a storage sytem for the AI settings
-  Add temporary languageModelRequirements to the `DefaultChatAgent`?
- Implement `LanguageModelRegistry.selectLanguageModel` method for the fronted language model registry

#### How to test

- Open the AI Settings view from the Open view... menu
- The view will display a list of all the available agents (currently only the Chat agent exists) and their properties
- Select one of the available purposes of the Agent 
- Select one of the available language models
- The Language model selection should be persisted in the Theia preferences 
- The Agent should use the selected model

https://github.com/user-attachments/assets/0aed1779-bfa4-466d-a8a5-61e23d5b881a



