### PR TITLE
Create initial version of terminal command agent

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -24,6 +24,7 @@
     "@theia/ai-chat-ui": "1.49.0",
     "@theia/ai-core": "1.49.0",
     "@theia/ai-openai": "1.49.0",
+    "@theia/ai-terminal": "1.49.0",
     "@theia/api-provider-sample": "1.49.0",
     "@theia/api-samples": "1.49.0",
     "@theia/bulk-edit": "1.49.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../packages/ai-openai"
     },
     {
+      "path": "../../packages/ai-terminal"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -30,6 +30,7 @@
     "@theia/ai-chat-ui": "1.49.0",
     "@theia/ai-core": "1.49.0",
     "@theia/ai-openai": "1.49.0",
+    "@theia/ai-terminal": "1.49.0",
     "@theia/api-provider-sample": "1.49.0",
     "@theia/api-samples": "1.49.0",
     "@theia/bulk-edit": "1.49.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../packages/ai-openai"
     },
     {
+      "path": "../../packages/ai-terminal"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/packages/ai-terminal/.eslintrc.js
+++ b/packages/ai-terminal/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-terminal/README.md
+++ b/packages/ai-terminal/README.md
@@ -1,0 +1,33 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - AI Terminal EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/ai-terminal` extension contributes an overlay to the terminal view.\
+The overlay can be used to ask a dedicated `TerminalAgent` for suggestions of terminal commands.
+
+## Additional Information
+
+<!-- - [API documentation for `@theia/navigator`](https://eclipse-theia.github.io/theia/docs/next/modules/navigator.html) -->
+
+-   [Theia - GitHub](https://github.com/eclipse-theia/theia)
+-   [Theia - Website](https://theia-ide.org/)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/ai-terminal/package.json
+++ b/packages/ai-terminal/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/ai-terminal",
+  "version": "1.49.0",
+  "description": "Theia - AI Terminal Extension",
+  "dependencies": {
+    "@theia/core": "1.49.0",
+    "@theia/ai-core": "1.49.0",
+    "@theia/ai-chat": "1.49.0",
+    "@theia/terminal": "1.49.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/ai-terminal-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.49.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -1,0 +1,183 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Agent, isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelRegistry, LanguageModelResponse, PromptService } from '@theia/ai-core/lib/common';
+import { inject, injectable } from '@theia/core/shared/inversify';
+
+@injectable()
+export class AiTerminalAgent implements Agent {
+
+    id = 'ai-terminal';
+    name = 'AI Terminal Assistant';
+    description = `
+        This agent provides an AI assistant in the terminal.
+        It accesses the terminal environment, past terminal commands of the terminal session,
+        and recent terminal output to provide context-aware assistance.`;
+    variables = [];
+    promptTemplates = [
+        {
+            id: 'ai-terminal:system-prompt',
+            name: 'AI Terminal System Prompt',
+            description: 'Prompt for the AI Terminal Assistant',
+            template: `
+# Instructions
+Generate one or more command suggestions based on the user's request, considering the shell being used,
+the current working directory, and the recent terminal contents. Provide the best suggestion first,
+followed by other relevant suggestions if the user asks for further options. 
+
+Parameters:
+- user-request: The user's question or request.
+- shell: The shell being used, e.g., /usr/bin/zsh.
+- cwd: The current working directory.
+- recent-terminal-contents: The last 0 to 50 recent lines visible in the terminal.
+
+Return the result in the following JSON format:
+{
+  "commands": [
+    "best_command_suggestion",
+    "next_best_command_suggestion",
+    "another_command_suggestion"
+  ]
+}
+
+## Example
+user-request: "How do I commit changes?"
+shell: "/usr/bin/zsh"
+cwd: "/home/user/project"
+recent-terminal-contents:
+git status
+On branch main
+Your branch is up to date with 'origin/main'.
+nothing to commit, working tree clean
+
+## Expected JSON output
+\`\`\`json
+\{
+  "commands": [
+    "git commit",
+    "git commit --amend",
+    "git commit -a"
+  ]
+}
+\`\`\`
+`
+        },
+        {
+            id: 'ai-terminal:user-prompt',
+            name: 'AI Terminal User Prompt',
+            description: 'Prompt that contains the user request',
+            template: `
+user-request: \${userRequest}
+shell: \${shell}
+cwd: \${cwd}
+recent-terminal-contents:
+\${recentTerminalContents}
+`
+        }
+    ];
+    languageModelRequirements = [
+        {
+            actor: this.id,
+            purpose: 'suggest-terminal-commands',
+        }
+    ];
+
+    @inject(LanguageModelRegistry)
+    protected languageModelRegistry: LanguageModelRegistry;
+
+    @inject(PromptService)
+    protected promptService: PromptService;
+
+    async getCommands(input: {
+        userRequest: string,
+        cwd: string,
+        shell: string,
+        recentTerminalContents: string[],
+    }): Promise<string[]> {
+
+        const lms = await this.languageModelRegistry.selectLanguageModels(this.languageModelRequirements[0]);
+        if (lms.length === 0) {
+            console.error('No language model available for the AI Terminal Agent.');
+            return [];
+        }
+
+        const lm = lms[0];
+
+        const systemPrompt = this.promptService.getPrompt('ai-terminal:system-prompt', input)!;
+        const userPrompt = this.promptService.getPrompt('ai-terminal:user-prompt', input)!;
+
+        const result = await lm.request({
+            messages: [
+                {
+                    actor: 'ai',
+                    type: 'text',
+                    query: systemPrompt
+                },
+                {
+                    actor: 'user',
+                    type: 'text',
+                    query: userPrompt
+                }
+            ]
+        });
+
+        const contentResult = await this.waitAndGet(result);
+        const commands = this.parseJsonBlock(contentResult);
+
+        return commands;
+    }
+
+    protected async waitAndGet(response: LanguageModelResponse): Promise<string> {
+        if (isLanguageModelTextResponse(response)) {
+            return response.text;
+        }
+        if (isLanguageModelStreamResponse(response)) {
+            let content = '';
+            for await (const token of response.stream) {
+                content += token.content;
+            }
+            return content;
+        }
+        return '';
+    }
+
+    protected parseJsonBlock(input: string): string[] {
+        const regex = /```json\s*([\s\S]*?)\s*```/g;
+        let match;
+
+        // try finding ```json ... ```
+        // eslint-disable-next-line no-null/no-null
+        while ((match = regex.exec(input)) !== null) {
+            try {
+                const jsonData = JSON.parse(match[1]);
+                if (jsonData.commands) {
+                    return jsonData.commands;
+                }
+            } catch (error) {
+                console.error('Failed to parse JSON:', error);
+            }
+        }
+
+        // try parsing directly
+        const data = JSON.parse(input);
+        if (data.commands) {
+            return data.commands;
+        }
+
+        return [];
+    }
+
+}

--- a/packages/ai-terminal/src/browser/ai-terminal-contribution.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-contribution.ts
@@ -1,0 +1,165 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
+import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { TerminalWidgetImpl } from '@theia/terminal/lib/browser/terminal-widget-impl';
+import { AiTerminalAgent } from './ai-terminal-agent';
+
+const AI_TERMINAL_COMMAND = {
+    id: 'ai-terminal:open',
+    label: 'Start AI Chat'
+};
+
+@injectable()
+export class AiTerminalCommandContribution implements CommandContribution, MenuContribution, KeybindingContribution {
+
+    @inject(TerminalService)
+    protected terminalService: TerminalService;
+
+    @inject(AiTerminalAgent)
+    protected terminalAgent: AiTerminalAgent;
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: AI_TERMINAL_COMMAND.id,
+            keybinding: 'ctrlcmd+i',
+            when: 'terminalFocus'
+        });
+    }
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction([...TerminalMenus.TERMINAL_CONTEXT_MENU, '_5'], {
+            commandId: AI_TERMINAL_COMMAND.id
+        });
+    }
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(AI_TERMINAL_COMMAND, {
+            execute: () => {
+                if (this.terminalService.currentTerminal instanceof TerminalWidgetImpl) {
+                    new AiTerminalChatWidget(
+                        this.terminalService.currentTerminal,
+                        this.terminalAgent
+                    );
+                }
+            }
+        });
+    }
+}
+
+class AiTerminalChatWidget {
+
+    protected chatContainer: HTMLDivElement;
+    protected chatInput: HTMLTextAreaElement;
+    protected chatResultParagraph: HTMLParagraphElement;
+    protected chatInputContainer: HTMLDivElement;
+
+    protected haveResult = false;
+
+    constructor(
+        protected terminalWidget: TerminalWidgetImpl,
+        protected terminalAgent: AiTerminalAgent
+    ) {
+        this.chatContainer = document.createElement('div');
+        this.chatContainer.className = 'ai-terminal-chat-container';
+
+        const chatResultContainer = document.createElement('div');
+        chatResultContainer.className = 'ai-terminal-chat-result';
+        this.chatResultParagraph = document.createElement('p');
+        this.chatResultParagraph.textContent = 'How can I help you?';
+        chatResultContainer.appendChild(this.chatResultParagraph);
+        this.chatContainer.appendChild(chatResultContainer);
+
+        this.chatInputContainer = document.createElement('div');
+        this.chatInputContainer.className = 'ai-terminal-chat-input-container';
+
+        this.chatInput = document.createElement('textarea');
+        this.chatInput.className = 'theia-input theia-ChatInput';
+        this.chatInput.placeholder = 'Ask about a terminal command...';
+        this.chatInput.onkeydown = event => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                if (!this.haveResult) {
+                    this.send();
+                } else {
+                    this.terminalWidget.sendText(this.chatResultParagraph.innerText);
+                    this.dispose();
+                }
+            } else if (event.key === 'Escape') {
+                this.dispose();
+            }
+        };
+        this.chatInputContainer.appendChild(this.chatInput);
+
+        const chatInputOptionsContainer = document.createElement('div');
+        const chatInputOptionsSpan = document.createElement('span');
+        chatInputOptionsSpan.className = 'codicon codicon-send option';
+        chatInputOptionsSpan.title = 'Send';
+        chatInputOptionsSpan.onclick = () => this.send();
+        chatInputOptionsContainer.appendChild(chatInputOptionsSpan);
+        this.chatInputContainer.appendChild(chatInputOptionsContainer);
+
+        this.chatContainer.appendChild(this.chatInputContainer);
+
+        terminalWidget.node.appendChild(this.chatContainer);
+
+        this.chatInput.focus();
+    }
+
+    protected async send(): Promise<void> {
+        const userRequest = this.chatInput.value;
+        if (userRequest) {
+            this.chatInput.value = '';
+
+            this.chatResultParagraph.innerText = 'Loading';
+            this.chatResultParagraph.className = 'loading';
+
+            const cwd = (await this.terminalWidget.cwd).toString();
+            const processInfo = await this.terminalWidget.processInfo;
+            const shell = processInfo.executable;
+            const recentTerminalContents = this.getRecentTerminalCommands();
+            const commands = await this.terminalAgent.getCommands(
+                { userRequest, cwd, shell, recentTerminalContents }
+            );
+
+            if (commands.length > 0) {
+                this.chatResultParagraph.className = 'command';
+                this.chatResultParagraph.innerText = commands[0];
+                this.chatInput.placeholder = 'Hit enter to confirm or try again...';
+                this.haveResult = true;
+            } else {
+                this.chatResultParagraph.className = '';
+                this.chatResultParagraph.innerText = 'No results';
+                this.chatInput.placeholder = 'Try again...';
+            }
+        }
+    }
+
+    private getRecentTerminalCommands(): string[] {
+        const maxLines = 100;
+        return this.terminalWidget.buffer.getLines(0,
+            this.terminalWidget.buffer.length > maxLines ? maxLines : this.terminalWidget.buffer.length
+        );
+    }
+
+    protected dispose(): void {
+        this.chatInput.value = '';
+        this.terminalWidget.node.removeChild(this.chatContainer);
+        this.terminalWidget.getTerminal().focus();
+    }
+}

--- a/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Agent } from '@theia/ai-core/lib/common';
+import { CommandContribution, MenuContribution } from '@theia/core';
+import { KeybindingContribution } from '@theia/core/lib/browser';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { AiTerminalAgent } from './ai-terminal-agent';
+import { AiTerminalCommandContribution } from './ai-terminal-contribution';
+
+import '../../src/browser/style/ai-terminal.css';
+
+export default new ContainerModule(bind => {
+    bind(AiTerminalCommandContribution).toSelf().inSingletonScope();
+    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution]) {
+        bind(identifier).toService(AiTerminalCommandContribution);
+    }
+
+    bind(AiTerminalAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(AiTerminalAgent);
+});

--- a/packages/ai-terminal/src/browser/style/ai-terminal.css
+++ b/packages/ai-terminal/src/browser/style/ai-terminal.css
@@ -1,0 +1,83 @@
+.ai-terminal-chat-container {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 500px;
+  padding: 10px;
+  box-sizing: border-box;
+  background: var(--theia-menu-background);
+  color: var(--theia-menu-foreground);
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid var(--theia-menu-border);
+}
+
+.ai-terminal-chat-result {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.ai-terminal-chat-input-container {
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.ai-terminal-chat-input-container textarea {
+  flex-grow: 1;
+  height: 36px;
+  background-color: var(--theia-input-background);
+  border-radius: 4px;
+  box-sizing: border-box;
+  padding: 8px;
+  resize: none;
+  overflow: hidden;
+  line-height: 1.3rem;
+  margin-right: 10px; /* Add some space between textarea and button */
+}
+
+.ai-terminal-chat-input-container .option {
+  width: 21px;
+  height: 21px;
+  display: inline-block;
+  box-sizing: border-box;
+  user-select: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  border: var(--theia-border-width) solid transparent;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.ai-terminal-chat-input-container .option:hover {
+  opacity: 1;
+}
+
+@keyframes dots {
+  0%,
+  20% {
+    content: "";
+  }
+  40% {
+    content: ".";
+  }
+  60% {
+    content: "..";
+  }
+  80%,
+  100% {
+    content: "...";
+  }
+}
+.ai-terminal-chat-result p.loading::after {
+  content: "";
+  animation: dots 1s steps(1, end) infinite;
+}
+
+.ai-terminal-chat-result p.command {
+  font-family: "Droid Sans Mono", "monospace", monospace;
+}

--- a/packages/ai-terminal/src/browser/style/ai-terminal.css
+++ b/packages/ai-terminal/src/browser/style/ai-terminal.css
@@ -16,6 +16,17 @@
   border: 1px solid var(--theia-menu-border);
 }
 
+.ai-terminal-chat-container .closeButton {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  cursor: pointer;
+}
+
+.ai-terminal-chat-container .closeButton:hover {
+  color: var(--theia-menu-foreground);
+}
+
 .ai-terminal-chat-result {
   width: 100%;
   margin-bottom: 10px;

--- a/packages/ai-terminal/tsconfig.json
+++ b/packages/ai-terminal/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-chat"
+    },
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../terminal"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,6 +67,9 @@
       "path": "packages/ai-openai"
     },
     {
+      "path": "packages/ai-terminal"
+    },
+    {
       "path": "packages/bulk-edit"
     },
     {


### PR DESCRIPTION
#### What it does

Adds an initial simple version of a terminal command agent.

[Screencast from 07-30-2024 11:39:03 AM.webm](https://github.com/user-attachments/assets/5390db41-c68a-4471-8de1-5f73af92733b)

https://github.com/eclipsesource/osweek-2024/issues/14

#### How to test

Open a terminal and right-click to select "Start AI Chat" or hit Ctrl-i.

#### Follow-ups

* UX: Allow to switch to alternative commands e.g. clicking Alt-left/Alt-right
* UX: Add a close icon to the overlay
* Architecture: Consider harmonizing UI with Chat UI