### PR TITLE
fix: initialize language model select UI on startup

### DIFF
--- a/packages/ai-core/src/browser/ai-settings-widget.tsx
+++ b/packages/ai-core/src/browser/ai-settings-widget.tsx
@@ -47,7 +47,7 @@ export class AISettingsWidget extends ReactWidget {
     // map from agent id to selected purpose
     protected selectedPurposes: Map<string, string> = new Map();
     // map from agent id to selected purpose and model
-    protected selectedModels: Map<string, Map<string, LanguageModel>> = new Map();
+    protected selectedModels: Map<string, Map<string, string>> = new Map();
 
     @postConstruct()
     protected init(): void {
@@ -60,6 +60,18 @@ export class AISettingsWidget extends ReactWidget {
         this.languageModelRegistry.getLanguageModels().then(models => {
             this.languageModels = models ?? [];
             this.update();
+        });
+
+        this.agents.getContributions().forEach(agent => {
+            const settings = this.aiSettingsService.getAgentSettings(agent.id);
+            settings?.languageModelRequirements.forEach(req => {
+                if (this.selectedModels.get(agent.id) === undefined) {
+                    this.selectedModels.set(agent.id, new Map());
+                }
+                if (req.identifier) {
+                    this.selectedModels.get(agent.id)?.set(req.purpose, req.identifier)
+                }
+            })
         });
 
         this.update();
@@ -75,16 +87,11 @@ export class AISettingsWidget extends ReactWidget {
             console.error('No purpose selected');
             return;
         }
-        const selectedModel = this.languageModels?.find(model => model.id === event.target.value);
-        if (!selectedModel) {
-            console.error('Could not find language model with id', event.target.value);
-            return;
-        }
         if (this.selectedModels.get(agentId) === undefined) {
             this.selectedModels.set(agentId, new Map());
         }
-        this.selectedModels.get(agentId)!.set(selectedPurpose, selectedModel);
-        this.aiSettingsService.updateAgentSettings(agentId, { languageModelRequirements: [{ purpose: selectedPurpose, identifier: selectedModel.id }] });
+        this.selectedModels.get(agentId)!.set(selectedPurpose, event.target.value);
+        this.aiSettingsService.updateAgentSettings(agentId, { languageModelRequirements: [{ purpose: selectedPurpose, identifier: event.target.value }] });
         this.update();
     };
 
@@ -125,7 +132,7 @@ export class AISettingsWidget extends ReactWidget {
                                     <select
                                         className="theia-select"
                                         id={`model-select-${agent.id}`}
-                                        value={this.selectedModels?.get(agent.id)?.get(this.selectedPurposes.get(agent.id)!)?.id}
+                                        value={this.selectedModels?.get(agent.id)?.get(this.selectedPurposes.get(agent.id)!)}
                                         onChange={event => this.onSelectedModelChange(agent.id, event)}
                                     >
                                         <option value=""></option>


### PR DESCRIPTION
Part of https://github.com/eclipsesource/osweek-2024/issues/59
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
The language model selection value should be initialized with the value from settings if it exists

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- in the AI settings view, for one of the agents select a purpose  and a language model
- close the view and reopen it
- select the same purpose that was updated before -> the language model dropdown should display the previously selected value

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


