### PR TITLE
Project-aware Chat Agent

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -29,6 +29,7 @@
     "@theia/ai-openai": "1.52.0",
     "@theia/ai-terminal": "1.52.0",
     "@theia/ai-llamafile": "1.52.0",
+    "@theia/ai-theia-agents": "1.52.0",
     "@theia/api-provider-sample": "1.52.0",
     "@theia/api-samples": "1.52.0",
     "@theia/bulk-edit": "1.52.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-theia-agents"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -35,6 +35,7 @@
     "@theia/ai-openai": "1.52.0",
     "@theia/ai-terminal": "1.52.0",
     "@theia/ai-llamafile": "1.52.0",
+    "@theia/ai-theia-agents": "1.52.0",
     "@theia/api-provider-sample": "1.52.0",
     "@theia/api-samples": "1.52.0",
     "@theia/bulk-edit": "1.52.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -39,6 +39,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-theia-agents"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -109,36 +109,23 @@ export class DefaultChatAgent implements ChatAgent {
         //         type: 'function',
         //         function: {
         //             name: 'getProjectFileList',
-        //             description: 'Get the list of files in the current project',
-        //             parameters: {
-        //                 type: 'object',
-        //                 properties: {
-        //                     unit: {
-        //                         'description': 'The city and state, e.g. San Francisco, CA',
-        //                         'type': 'string',
-        //                         'enum': ['celsius', 'fahrenheit']
-        //                     }
-        //                 },
-        //                 required: ['unit']
-        //             },
-
+        //             description: 'Get the list of files in the current project'
         //         }
         //     },
         //     {
         //         type: 'function',
         //         function: {
         //             name: 'getFileContent',
-        //             description: 'Get the current weather in a given location',
+        //             description: 'Get the content of the file',
         //             parameters: {
         //                 type: 'object',
         //                 properties: {
-        //                     unit: {
-        //                         'description': 'The city and state, e.g. San Francisco, CA',
+        //                     file: {
+        //                         'description': 'The path of the file to retrieve content for',
         //                         'type': 'string',
-        //                         'enum': ['celsius', 'fahrenheit']
         //                     }
         //                 },
-        //                 required: ['unit']
+        //                 required: ['file']
         //             }
         //         }
         //     }

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -19,7 +19,7 @@
  *--------------------------------------------------------------------------------------------*/
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatAgents.ts
 
-import { CommunicationRecordingService, LanguageModelRequirement } from '@theia/ai-core';
+import { CommunicationRecordingService, LanguageModel, LanguageModelResponse, LanguageModelRequirement } from '@theia/ai-core';
 import {
     Agent,
     isLanguageModelStreamResponse,
@@ -28,10 +28,10 @@ import {
     PromptTemplate
 } from '@theia/ai-core/lib/common';
 import { TODAY_VARIABLE } from '@theia/ai-core/lib/today-variable-contribution';
-import { generateUuid, ILogger, isArray } from '@theia/core';
+import { generateUuid, ILogger, isArray, MaybePromise } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { ChatRequestModelImpl, ChatResponseContent, CodeChatResponseContentImpl, MarkdownChatResponseContentImpl } from './chat-model';
-import { getMessages } from './chat-util';
+import { ChatModel, ChatRequestModelImpl, ChatResponseContent, CodeChatResponseContentImpl, MarkdownChatResponseContentImpl } from './chat-model';
+import { ChatMessage } from './chat-util';
 
 export enum ChatAgentLocation {
     Panel = 'panel',
@@ -91,18 +91,20 @@ export class DefaultChatAgent implements ChatAgent {
     locations: ChatAgentLocation[] = ChatAgentLocation.ALL;
 
     async invoke(request: ChatRequestModelImpl): Promise<void> {
-        this.recordingService.recordRequest({
-            agentId: this.id,
-            sessionId: request.session.id,
-            timestamp: Date.now(),
-            requestId: request.id,
-            request: request.request.text
-        });
         const selector = this.languageModelRequirements.find(req => req.purpose === 'chat')!;
         const languageModels = await this.languageModelRegistry.selectLanguageModels({ agent: this.id, ...selector });
         if (languageModels.length === 0) {
             throw new Error('Couldn\'t find a language model. Please check your setup!');
         }
+        const messages = await this.getMessages(request.session);
+        this.recordingService.recordRequest({
+            agentId: this.id,
+            sessionId: request.session.id,
+            timestamp: Date.now(),
+            requestId: request.id,
+            request: request.request.text,
+            messages
+        });
 
         // [
         //     {
@@ -131,7 +133,7 @@ export class DefaultChatAgent implements ChatAgent {
         //     }
         // ]
 
-        const languageModelResponse = await languageModels[0].request({ messages: getMessages(request.session) });
+        const languageModelResponse = await this.callLlm(languageModels[0], messages);
         if (isLanguageModelTextResponse(languageModelResponse)) {
             request.response.response.addContent(
                 new MarkdownChatResponseContentImpl(languageModelResponse.text)
@@ -225,6 +227,41 @@ export class DefaultChatAgent implements ChatAgent {
             requestId: request.response.requestId,
             response: request.response.response.asString()
         });
+    }
+
+    protected async callLlm(languageModel: LanguageModel, messages: ChatMessage[]): Promise<LanguageModelResponse> {
+        const languageModelResponse = languageModel.request({ messages });
+        return languageModelResponse;
+    }
+
+    protected getMessages(model: ChatModel, includeResponseInProgress = false, systemMessage?: string): MaybePromise<ChatMessage[]> {
+        const requestMessages = model.getRequests().flatMap(request => {
+            const messages: ChatMessage[] = [];
+            const query = request.message.parts.map(part => part.promptText).join('');
+            messages.push({
+                actor: 'user',
+                type: 'text',
+                query,
+            });
+            if (request.response.isComplete || includeResponseInProgress) {
+                messages.push({
+                    actor: 'ai',
+                    type: 'text',
+                    query: request.response.response.asString(),
+                });
+            }
+            return messages;
+        });
+        if (systemMessage) {
+            const systemMsg: ChatMessage = {
+                actor: 'system',
+                type: 'text',
+                query: systemMessage
+            };
+            // insert systemMsg at the beginning of requestMessages
+            requestMessages.unshift(systemMsg);
+        }
+        return requestMessages;
     }
 
     private parse(token: LanguageModelStreamResponsePart, previousContent: ChatResponseContent[]): ChatResponseContent | ChatResponseContent[] {

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -106,33 +106,6 @@ export class DefaultChatAgent implements ChatAgent {
             messages
         });
 
-        // [
-        //     {
-        //         type: 'function',
-        //         function: {
-        //             name: 'getProjectFileList',
-        //             description: 'Get the list of files in the current project'
-        //         }
-        //     },
-        //     {
-        //         type: 'function',
-        //         function: {
-        //             name: 'getFileContent',
-        //             description: 'Get the content of the file',
-        //             parameters: {
-        //                 type: 'object',
-        //                 properties: {
-        //                     file: {
-        //                         'description': 'The path of the file to retrieve content for',
-        //                         'type': 'string',
-        //                     }
-        //                 },
-        //                 required: ['file']
-        //             }
-        //         }
-        //     }
-        // ]
-
         const languageModelResponse = await this.callLlm(languageModels[0], messages);
         if (isLanguageModelTextResponse(languageModelResponse)) {
             request.response.response.addContent(

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -103,6 +103,47 @@ export class DefaultChatAgent implements ChatAgent {
         if (languageModels.length === 0) {
             throw new Error('Couldn\'t find a language model. Please check your setup!');
         }
+
+        // [
+        //     {
+        //         type: 'function',
+        //         function: {
+        //             name: 'getProjectFileList',
+        //             description: 'Get the list of files in the current project',
+        //             parameters: {
+        //                 type: 'object',
+        //                 properties: {
+        //                     unit: {
+        //                         'description': 'The city and state, e.g. San Francisco, CA',
+        //                         'type': 'string',
+        //                         'enum': ['celsius', 'fahrenheit']
+        //                     }
+        //                 },
+        //                 required: ['unit']
+        //             },
+
+        //         }
+        //     },
+        //     {
+        //         type: 'function',
+        //         function: {
+        //             name: 'getFileContent',
+        //             description: 'Get the current weather in a given location',
+        //             parameters: {
+        //                 type: 'object',
+        //                 properties: {
+        //                     unit: {
+        //                         'description': 'The city and state, e.g. San Francisco, CA',
+        //                         'type': 'string',
+        //                         'enum': ['celsius', 'fahrenheit']
+        //                     }
+        //                 },
+        //                 required: ['unit']
+        //             }
+        //         }
+        //     }
+        // ]
+
         const languageModelResponse = await languageModels[0].request({ messages: getMessages(request.session) });
         if (isLanguageModelTextResponse(languageModelResponse)) {
             request.response.response.addContent(

--- a/packages/ai-chat/src/common/chat-util.ts
+++ b/packages/ai-chat/src/common/chat-util.ts
@@ -13,10 +13,10 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { ChatActor } from '@theia/ai-core';
+import { MessageActor } from '@theia/ai-core';
 
 export interface ChatMessage {
-    actor: ChatActor;
+    actor: MessageActor;
     type: 'text';
     query: string;
 }

--- a/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
@@ -14,9 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as React from '@theia/core/shared/react';
-import { Agent } from '../../common';
+import { Agent, LanguageModelRequirement } from '../../common';
 import { LanguageModel } from '../../common/language-model';
-import { AISettingsService, LanguageModelRequirement } from '../ai-settings-service';
+import { AISettingsService } from '../ai-settings-service';
 
 export interface LanguageModelSettingsProps {
     agent: Agent;

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -32,9 +32,6 @@ import {
     PromptCustomizationService,
     PromptService,
     PromptServiceImpl,
-    PromptCustomizationService,
-    AIVariableContribution,
-    AIVariableService,
     LanguageModelToolServer,
     LanguageModelToolServiceFrontend,
     languageModelToolServicePath

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -31,7 +31,13 @@ import {
     LanguageModelRegistryFrontendDelegate,
     PromptCustomizationService,
     PromptService,
-    PromptServiceImpl
+    PromptServiceImpl,
+    PromptCustomizationService,
+    AIVariableContribution,
+    AIVariableService,
+    LanguageModelToolServer,
+    LanguageModelToolServiceFrontend,
+    languageModelToolServicePath
 } from '../common';
 import {
     FrontendLanguageModelRegistryImpl,
@@ -54,6 +60,7 @@ import { bindPromptPreferences } from './prompt-preferences';
 import { PromptTemplateContribution } from './prompttemplate-contribution';
 import { TomorrowVariableContribution } from '../tomorrow-variable-contribution';
 import { AIConfigurationSelectionService } from './ai-configuration/ai-configuration-service';
+import { LanguageModelToolServiceFrontendImpl } from './language-model-tool-service-frontend';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -125,5 +132,14 @@ export default new ContainerModule(bind => {
             id: AIAgentConfigurationWidget.ID,
             createWidget: () => ctx.container.get(AIAgentConfigurationWidget)
         }))
+        .inSingletonScope();
+
+    bind(LanguageModelToolServiceFrontend).to(LanguageModelToolServiceFrontendImpl).inSingletonScope();
+    bind(LanguageModelToolServer)
+        .toDynamicValue(ctx => {
+            const connection = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+            const client = ctx.container.get<LanguageModelToolServiceFrontend>(LanguageModelToolServiceFrontend);
+            return connection.createProxy<LanguageModelToolServer>(languageModelToolServicePath, client);
+        })
         .inSingletonScope();
 });

--- a/packages/ai-core/src/browser/ai-settings-service.ts
+++ b/packages/ai-core/src/browser/ai-settings-service.ts
@@ -54,5 +54,3 @@ export interface AISettings extends JSONObject {
 interface AgentSettings extends JSONObject {
     languageModelRequirements: LanguageModelRequirement[];
 }
-
-export type LanguageModelRequirement = Omit<LanguageModelSelector, 'agent'>;

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -39,6 +39,7 @@ import {
     LanguageModelResponse,
     LanguageModelSelector,
     LanguageModelStreamResponsePart,
+    LanguageModelToolServer,
 } from '../common';
 import { AISettingsService } from './ai-settings-service';
 
@@ -87,6 +88,9 @@ export class FrontendLanguageModelRegistryImpl
 
     @inject(AISettingsService)
     protected settingsService: AISettingsService;
+    
+    @inject(LanguageModelToolServer)
+    protected toolServer: LanguageModelToolServer;
 
     override addLanguageModels(models: LanguageModelMetaData[] | LanguageModel[]): void {
         models.map(model => {

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -88,7 +88,10 @@ export class FrontendLanguageModelRegistryImpl
 
     @inject(AISettingsService)
     protected settingsService: AISettingsService;
-    
+
+    // We don't use the tool server in the frontend, but we still need to initialize
+    // the binding, to let the tool service client register itself to the server.
+    // This injection is used to eagerly initialize the server binding.
     @inject(LanguageModelToolServer)
     protected toolServer: LanguageModelToolServer;
 

--- a/packages/ai-core/src/browser/language-model-tool-service-frontend.ts
+++ b/packages/ai-core/src/browser/language-model-tool-service-frontend.ts
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { injectable } from '@theia/core/shared/inversify';
+import { LanguageModelToolServiceFrontend } from '../common';
+
+@injectable()
+export class LanguageModelToolServiceFrontendImpl implements LanguageModelToolServiceFrontend {
+    private callbackMap: Map<string, (toolId: string, arg_string: string) => unknown> = new Map();
+
+    registerToolCallback(agentId: string, callback: (toolId: string, arg_string: string) => unknown): void {
+        this.callbackMap.set(agentId, callback);
+    }
+    async callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown> {
+        const callback = this.callbackMap.get(agentId);
+        if (callback) {
+            return callback(toolId, arg_string);
+        } else {
+            return Promise.reject(new Error(`No callback registered for agentId ${agentId}`));
+        }
+    }
+}

--- a/packages/ai-core/src/common/agent.ts
+++ b/packages/ai-core/src/common/agent.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelSelector } from './language-model';
+import { LanguageModelRequirement } from './language-model';
 import { PromptTemplate } from './types';
 
 export const Agent = Symbol('Agent');
@@ -37,5 +37,3 @@ export interface Agent {
     /** Required language models. This includes the purpose and optional language model selector arguments. See #47. */
     readonly languageModelRequirements: LanguageModelRequirement[];
 }
-
-export type LanguageModelRequirement = Omit<LanguageModelSelector, 'agent'>;

--- a/packages/ai-core/src/common/communication-recording-service.ts
+++ b/packages/ai-core/src/common/communication-recording-service.ts
@@ -26,6 +26,7 @@ export interface CommunicationHistoryEntry {
     request?: string;
     response?: string;
     responseTime?: number;
+    messages?: unknown[];
 }
 
 export type CommunicationRequestEntry = Omit<CommunicationHistoryEntry, 'response' | 'responseTime'>;

--- a/packages/ai-core/src/common/language-model-tool-service.ts
+++ b/packages/ai-core/src/common/language-model-tool-service.ts
@@ -14,28 +14,18 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 // import { ToolRequest } from './language-model';
-
+export const languageModelToolServicePath = '/services/languageModelToolService';
+export const LanguageModelToolServiceFrontend = Symbol('LanguageModelToolServiceFrontend');
 export interface LanguageModelToolServiceFrontend {
     registerToolCallback(agentId: string, callback: (toolId: string, arg_string: string) => unknown): void;
     callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown>;
 }
-export const LanguageModelToolService = Symbol('LanguageModelToolService');
+export const LanguageModelToolServer = Symbol('LanguageModelToolServer');
 export interface LanguageModelToolServer {
     callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown>;
     setClient(client: LanguageModelToolServiceFrontend): void;
 }
-// export class LanguageModelToolServiceImpl implements LanguageModelToolService {
-//     protected readonly tools: Map<string, (arg_string: string) => unknown> = new Map();
-//     protected client: LanguageModelToolServiceClient;
 
-//     setClient(client: LanguageModelToolServiceClient): void {
-//         this.client = client;
-//     }
-
-//     registerTool(tool: ToolRequest<object>, callback: (arg_string: string) => unknown): void {
-//         this.tools.set(tool.name, callback);
-//     }
-// }
 /**
  * F/B: agent -> resgiters at the toolservice
  * RPCClient: llm -> notifies the toolservice that a tool was called

--- a/packages/ai-core/src/common/language-model-tool-service.ts
+++ b/packages/ai-core/src/common/language-model-tool-service.ts
@@ -27,7 +27,7 @@ export interface LanguageModelToolServer {
 }
 
 /**
- * F/B: agent -> resgiters at the toolservice
+ * F/B: agent -> registers at the toolservice
  * RPCClient: llm -> notifies the toolservice that a tool was called
  * F/B: toolservice -> notifies the agent that a tool was called
  * F/B: agent returns the tool call result -> toolservice

--- a/packages/ai-core/src/common/language-model-tool-service.ts
+++ b/packages/ai-core/src/common/language-model-tool-service.ts
@@ -13,7 +13,6 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-// import { ToolRequest } from './language-model';
 export const languageModelToolServicePath = '/services/languageModelToolService';
 export const LanguageModelToolServiceFrontend = Symbol('LanguageModelToolServiceFrontend');
 export interface LanguageModelToolServiceFrontend {

--- a/packages/ai-core/src/common/language-model-tool-service.ts
+++ b/packages/ai-core/src/common/language-model-tool-service.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+// import { ToolRequest } from './language-model';
+
+export interface LanguageModelToolServiceFrontend {
+    registerToolCallback(agentId: string, callback: (toolId: string, arg_string: string) => unknown): void;
+    callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown>;
+}
+export const LanguageModelToolService = Symbol('LanguageModelToolService');
+export interface LanguageModelToolServer {
+    callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown>;
+    setClient(client: LanguageModelToolServiceFrontend): void;
+}
+// export class LanguageModelToolServiceImpl implements LanguageModelToolService {
+//     protected readonly tools: Map<string, (arg_string: string) => unknown> = new Map();
+//     protected client: LanguageModelToolServiceClient;
+
+//     setClient(client: LanguageModelToolServiceClient): void {
+//         this.client = client;
+//     }
+
+//     registerTool(tool: ToolRequest<object>, callback: (arg_string: string) => unknown): void {
+//         this.tools.set(tool.name, callback);
+//     }
+// }
+/**
+ * F/B: agent -> resgiters at the toolservice
+ * RPCClient: llm -> notifies the toolservice that a tool was called
+ * F/B: toolservice -> notifies the agent that a tool was called
+ * F/B: agent returns the tool call result -> toolservice
+ * RPCCLient: toolservice -> notifies llm about toolcall result
+ * 
+ */

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -127,6 +127,8 @@ export interface LanguageModelSelector extends VsCodeLanguageModelSelector {
     readonly purpose: string;
 }
 
+export type LanguageModelRequirement = Omit<LanguageModelSelector, 'agent'>;
+
 export const LanguageModelRegistry = Symbol('LanguageModelRegistry');
 export interface LanguageModelRegistry {
     addLanguageModels(models: LanguageModel[]): void;

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -33,12 +33,14 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
         typeof (obj as { query: unknown }).query === 'string'
     );
 export interface ToolRequest<T extends object> {
+    id: string;
     name: string;
     parameters?: { [key: string]: unknown };
     description?: string;
 }
 export interface LanguageModelRequest {
     messages: LanguageModelRequestMessage[],
+    agentId?: string;
     tools?: ToolRequest<object>[];
 }
 

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -17,7 +17,7 @@
 import { ContributionProvider, ILogger, isFunction, isObject } from '@theia/core';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 
-export type MessageActor = 'user' | 'ai';
+export type MessageActor = 'user' | 'ai' | 'system';
 
 export interface LanguageModelRequestMessage {
     actor: MessageActor;

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -36,8 +36,6 @@ export interface ToolRequest<T extends object> {
     name: string;
     parameters?: { [key: string]: unknown };
     description?: string;
-    callback: (args: T) => Promise<unknown>;
-    parse?: (input: string) => T;
 }
 export interface LanguageModelRequest {
     messages: LanguageModelRequestMessage[],

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -32,9 +32,16 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
         'query' in obj &&
         typeof (obj as { query: unknown }).query === 'string'
     );
-
+export interface ToolRequest<T extends object> {
+    name: string;
+    parameters?: { [key: string]: unknown };
+    description?: string;
+    callback: (args: T) => Promise<unknown>;
+    parse?: (input: string) => T;
+}
 export interface LanguageModelRequest {
-    messages: LanguageModelRequestMessage[]
+    messages: LanguageModelRequestMessage[],
+    tools?: ToolRequest<object>[];
 }
 
 export interface LanguageModelTextResponse {
@@ -185,4 +192,3 @@ export function isModelMatching(request: LanguageModelSelector, model: LanguageM
         (!request.version || model.version === request.version) &&
         (!request.family || model.family === request.family);
 }
-

--- a/packages/ai-core/src/node/ai-core-backend-module.ts
+++ b/packages/ai-core/src/node/ai-core-backend-module.ts
@@ -34,7 +34,11 @@ import {
     LanguageModelRegistryFrontendDelegate,
     languageModelDelegatePath,
     languageModelRegistryDelegatePath,
+    LanguageModelToolServer,
+    LanguageModelToolServiceFrontend,
+    languageModelToolServicePath,
 } from '../common';
+import { LanguageModelToolServerImpl } from './language-model-tool-service-server';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -76,4 +80,21 @@ export default new ContainerModule(bind => {
     bind(PromptServiceImpl).toSelf().inSingletonScope();
     bind(PromptService).toService(PromptServiceImpl);
 
+    bind(LanguageModelToolServer).to(LanguageModelToolServerImpl).inSingletonScope();
+    bind(ConnectionHandler)
+        .toDynamicValue(
+            ({ container }) =>
+                new RpcConnectionHandler<LanguageModelToolServiceFrontend>(
+                    languageModelToolServicePath,
+                    client => {
+                        const service =
+                            container.get<LanguageModelToolServer>(
+                                LanguageModelToolServer
+                            );
+                        service.setClient(client);
+                        return service;
+                    }
+                )
+        )
+        .inSingletonScope();
 });

--- a/packages/ai-core/src/node/language-model-tool-service-server.ts
+++ b/packages/ai-core/src/node/language-model-tool-service-server.ts
@@ -13,12 +13,19 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-export * from './agent';
-export * from './communication-recording-service';
-export * from './language-model';
-export * from './language-model-delegate';
-export * from './language-model-util';
-export * from './prompt-service';
-export * from './types';
-export * from './variable-service';
-export * from './language-model-tool-service';
+import { injectable } from '@theia/core/shared/inversify';
+import { LanguageModelToolServer, LanguageModelToolServiceFrontend } from '../common';
+
+@injectable()
+export class LanguageModelToolServerImpl implements LanguageModelToolServer {
+
+    protected client: LanguageModelToolServiceFrontend;
+
+    async callTool(agentId: string, toolId: string, arg_string: string): Promise<unknown> {
+        return this.client.callTool(agentId, toolId, arg_string);
+    }
+
+    setClient(client: LanguageModelToolServiceFrontend): void {
+        this.client = client;
+    }
+}

--- a/packages/ai-openai/src/node/openai-model-provider.ts
+++ b/packages/ai-openai/src/node/openai-model-provider.ts
@@ -128,6 +128,9 @@ export class OpenAiModel implements LanguageModel {
         if (message.actor === 'user') {
             return { role: 'user', content: message.query };
         }
+        if (message.actor === 'system') {
+            return { role: 'system', content: message.query };
+        }
         return { role: 'system', content: '' };
     }
 

--- a/packages/ai-openai/src/node/openai-model-provider.ts
+++ b/packages/ai-openai/src/node/openai-model-provider.ts
@@ -79,18 +79,6 @@ export class OpenAiModel implements LanguageModel {
             });
         }
 
-        // const [stream1] = stream.tee();
-        // return {
-        //     stream: {
-        //         [Symbol.asyncIterator](): AsyncIterator<LanguageModelStreamResponsePart> {
-        //             return {
-        //                 next(): Promise<IteratorResult<LanguageModelStreamResponsePart>> {
-        //                     return stream1[Symbol.asyncIterator]().next().then(chunk => chunk.done ? chunk : { value: chunk.value.choices[0]?.delta, done: false });
-        //                 }
-        //             };
-        //         }
-        //     }
-        // };
         let runnerEnd = false;
 
         let resolve: (part: LanguageModelStreamResponsePart) => void;

--- a/packages/ai-openai/src/node/openai-model-provider.ts
+++ b/packages/ai-openai/src/node/openai-model-provider.ts
@@ -92,15 +92,17 @@ export class OpenAiModel implements LanguageModel {
         // };
         let runnerEnd = false;
 
+        let resolve: (part: LanguageModelStreamResponsePart) => void;
         runner.once('end', () => {
             runnerEnd = true;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            resolve(runner.finalChatCompletion as any);
         });
         // eslint-disable-next-line @typescript-eslint/tslint/config
         const asyncIterator = (async function* () {
-            let resolve: (part: LanguageModelStreamResponsePart) => void;
             runner.on('chunk', chunk => {
                 if (chunk.choices[0]?.delta.content) {
-                    resolve({ content: chunk.choices[0]?.delta.content });
+                    resolve({ ...chunk.choices[0]?.delta });
                 }
             });
             while (!runnerEnd) {

--- a/packages/ai-theia-agents/.eslintrc.js
+++ b/packages/ai-theia-agents/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-theia-agents/package.json
+++ b/packages/ai-theia-agents/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@theia/ai-theia-agents",
+  "version": "1.52.0",
+  "description": "AI Theia Agents Extension",
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "keywords": [
+    "theia-extension"
+  ],
+  "dependencies": {
+    "@theia/core": "1.52.0",
+    "@theia/filesystem": "1.52.0",
+    "@theia/workspace": "1.52.0",
+    "@theia/navigator": "1.52.0",
+    "@theia/terminal": "1.52.0",
+    "@theia/ai-core": "1.52.0",
+    "@theia/ai-chat": "1.52.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@theia/cli": "1.52.0",
+    "@theia/test": "1.52.0"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/frontend-module"
+    }
+  ],
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-theia-agents/src/browser/frontend-module.ts
+++ b/packages/ai-theia-agents/src/browser/frontend-module.ts
@@ -13,10 +13,13 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { ChatActor } from '@theia/ai-core';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { ChatAgent } from '@theia/ai-chat/lib/common';
+import { Agent } from '@theia/ai-core/lib/common';
+import { TheiaWorkspaceAgent } from './workspace-agent';
 
-export interface ChatMessage {
-    actor: ChatActor;
-    type: 'text';
-    query: string;
-}
+export default new ContainerModule(bind => {
+    bind(TheiaWorkspaceAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(TheiaWorkspaceAgent);
+    bind(ChatAgent).toService(TheiaWorkspaceAgent);
+});

--- a/packages/ai-theia-agents/src/browser/workspace-agent.ts
+++ b/packages/ai-theia-agents/src/browser/workspace-agent.ts
@@ -20,7 +20,7 @@ import { LanguageModel, LanguageModelResponse, PromptService, LanguageModelToolS
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core';
-import { FileStat } from '@theia/filesystem/src/common/files';
+import { FileStat } from '@theia/filesystem/lib/common/files';
 
 @injectable()
 export class TheiaWorkspaceAgent extends DefaultChatAgent implements ChatAgent {

--- a/packages/ai-theia-agents/src/browser/workspace-agent.ts
+++ b/packages/ai-theia-agents/src/browser/workspace-agent.ts
@@ -1,0 +1,38 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { ChatAgent, ChatMessage, ChatModel, ChatRequestParser, DefaultChatAgent } from '@theia/ai-chat/lib/common';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { template } from '../common/template';
+import { PromptService } from '@theia/ai-core';
+
+@injectable()
+export class TheiaWorkspaceAgent extends DefaultChatAgent implements ChatAgent {
+    override id = 'TheiaWorkspaceAgent';
+    override name = 'Workspace Agent';
+    override description = 'An AI Agent that can access the current Theia Workspace contents';
+    override promptTemplates = [template];
+
+    @inject(PromptService)
+    protected promptService: PromptService;
+
+    @inject(ChatRequestParser)
+    protected chatRequestParser: ChatRequestParser;
+
+    protected override async getMessages(model: ChatModel, includeResponseInProgress = false, systemMessage?: string): Promise<ChatMessage[]> {
+        const system = systemMessage ?? await this.promptService.getPrompt(template.id);
+        return super.getMessages(model, includeResponseInProgress, system);
+    }
+}

--- a/packages/ai-theia-agents/src/browser/workspace-agent.ts
+++ b/packages/ai-theia-agents/src/browser/workspace-agent.ts
@@ -141,8 +141,9 @@ export class TheiaWorkspaceAgent extends DefaultChatAgent implements ChatAgent {
     }
 
     async getFileContent(file: string): Promise<string> {
-        console.log('Calling getFileContent with file:', file);
-        return 'mock file content for ' + file;
+        const uri = new URI(file);
+        const fileContent = await this.fileService.read(uri);
+        return fileContent.value;
     }
 
 }

--- a/packages/ai-theia-agents/src/browser/workspace-agent.ts
+++ b/packages/ai-theia-agents/src/browser/workspace-agent.ts
@@ -16,7 +16,7 @@
 import { ChatAgent, ChatMessage, ChatModel, ChatRequestParser, DefaultChatAgent } from '@theia/ai-chat/lib/common';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { template } from '../common/template';
-import { LanguageModel, LanguageModelResponse, PromptService, LanguageModelToolServiceFrontend, LanguageModelToolServer } from '@theia/ai-core';
+import { LanguageModel, LanguageModelResponse, PromptService, LanguageModelToolServiceFrontend } from '@theia/ai-core';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core';
@@ -37,9 +37,6 @@ export class TheiaWorkspaceAgent extends DefaultChatAgent implements ChatAgent {
 
     @inject(LanguageModelToolServiceFrontend)
     protected toolService: LanguageModelToolServiceFrontend;
-
-    @inject(LanguageModelToolServer)
-    protected toolServer: LanguageModelToolServer;
 
     @inject(WorkspaceService)
     protected workspaceService: WorkspaceService;

--- a/packages/ai-theia-agents/src/common/template.ts
+++ b/packages/ai-theia-agents/src/common/template.ts
@@ -13,10 +13,14 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { ChatActor } from '@theia/ai-core';
+import { PromptTemplate } from '@theia/ai-core/lib/common';
 
-export interface ChatMessage {
-    actor: ChatActor;
-    type: 'text';
-    query: string;
-}
+export const template = <PromptTemplate>{
+    id: 'theia-workspace-prompt',
+    template: `You are an AI Agent to help developers with coding inside of the Theia IDE.
+    The user has the workspace open.
+    If needed, you can ask for more information.
+    The following functions are available to you:
+    - getProjectFiles(): return the list of files available in the project
+    - getFileContent(filePath: string): return the content of the file`
+};

--- a/packages/ai-theia-agents/src/common/template.ts
+++ b/packages/ai-theia-agents/src/common/template.ts
@@ -21,6 +21,8 @@ export const template = <PromptTemplate>{
     The user has the workspace open.
     If needed, you can ask for more information.
     The following functions are available to you:
-    - getProjectFiles(): return the list of files available in the project
-    - getFileContent(filePath: string): return the content of the file`
+    - getProjectFileList(): return the list of files available in the project
+    - getFileContent(filePath: string): return the content of the file
+
+Never shorten the file paths when using getFileContent.`
 };

--- a/packages/ai-theia-agents/tsconfig.json
+++ b/packages/ai-theia-agents/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../dev-packages/cli"
+    },
+    {
+      "path": "../ai-chat"
+    },
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../filesystem"
+    },
+    {
+      "path": "../navigator"
+    },
+    {
+      "path": "../terminal"
+    },
+    {
+      "path": "../test"
+    }
+  ]
+}

--- a/packages/ai-theia-agents/tsconfig.json
+++ b/packages/ai-theia-agents/tsconfig.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "../test"
+    },
+    {
+      "path": "../workspace"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,9 @@
       "path": "packages/ai-terminal"
     },
     {
+      "path": "packages/ai-theia-agents"
+    },
+    {
       "path": "packages/bulk-edit"
     },
     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR provides a new Agent (TheiaWorkspaceAgent), which is aware of the project contents. It has access to the contents of the workspace via two dedicated tools:

- getProjectFileList(): return the list of files available in the project
- getFileContent(filePath: string): return the content of the file

Most notably, this PR includes the following changes:

- ToolService, to register tools (currently on the frontend) that can be invoked by the backend (when the LLM Provider is defined)
- ~~The TheiaWorkspaceAgent is currently set as the default agent, because we don't have a way to pick specific agents (yet!)~~
  - ~~This can be reverted once https://github.com/eclipsesource/theia/pull/121 is merged~~
  - The above PR has been merged, so the Workspace agent needs to be queried with `@TheiaWorkspaceAgent`
- ChatMessages can now specify the type "System", in addition to "AI" and "user", to define the system prompt
- DefaultChatAgent was slightly refactored to make it easier to extend (especially to inject a system prompt from a custom template)
- Log the full message stack (Actor, Type and Query) in the AI Chat History

#### How to test

- open a workspace with a project (all workspace contents will be considered by the agent)
- ask the agent some information about the project (e.g. How do I build this project, or What is this project about?)
- **Important**: Prefix **all** your queries with `@TheiaWorkspaceAgent`, otherwise you'll fall back to the Default Agent which doesn't have access to the workspace

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

https://github.com/eclipsesource/osweek-2024/issues/76 and https://github.com/eclipsesource/osweek-2024/issues/77
