### PR TITLE
Improve code part renderer and default code content parsing

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -81,13 +81,15 @@ export class CodePartRenderer
         const uri = response.location?.uri;
         const position = response.location?.position;
         if (uri && position) {
-            return <a onClick={this.openFileAtPosition.bind(this, uri, position)}>{this.getTitle(response.location?.uri)}</a>;
+            return <a onClick={this.openFileAtPosition.bind(this, uri, position)}>{this.getTitle(response.location?.uri, response.language)}</a>;
         }
-        return this.getTitle(response.location?.uri);
+        return this.getTitle(response.location?.uri, response.language);
     }
 
-    private getTitle(uri: URI | undefined): string {
-        return uri?.path?.toString().split('/').pop() ?? 'Generated Code';
+    private getTitle(uri: URI | undefined, language: string | undefined): string {
+        // If there is a URI, use the file name as the title. Otherwise, use the language as the title.
+        // If there is no language, use a generic fallback title.
+        return uri?.path?.toString().split('/').pop() ?? language ?? 'Generated Code';
     }
 
     /**

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -309,10 +309,10 @@ export class MarkdownChatResponseContentImpl implements MarkdownChatResponseCont
 export class CodeChatResponseContentImpl implements CodeChatResponseContent {
     kind: 'code' = 'code';
     protected _code: string;
-    protected _language: string;
+    protected _language?: string;
     protected _location?: Location;
 
-    constructor(code: string, language: string, location?: Location) {
+    constructor(code: string, language?: string, location?: Location) {
         this._code = code;
         this._language = language;
         this._location = location;
@@ -322,7 +322,7 @@ export class CodeChatResponseContentImpl implements CodeChatResponseContent {
         return this._code;
     }
 
-    get language(): string {
+    get language(): string | undefined {
         return this._language;
     }
 


### PR DESCRIPTION
- Make language optional in CodeChatResponseContentImpl
- If given, show code language in the code part renderer top bar
- Improve code parsing in the default chat agent:
  - Remove language and leading new line from code block
  - Remove trailing whitespace from code block

How to test:

Tell the AI Chat to generate some code, e.g.:
Generate mergesort in 2 languages

Closes https://github.com/eclipsesource/osweek-2024/issues/70