### PR TITLE
Initial implementation of AI quick fixes in the Monaco editor

### DIFF
--- a/examples/browser-only/package.json
+++ b/examples/browser-only/package.json
@@ -18,6 +18,7 @@
     "@theia/ai-chat": "1.52.0",
     "@theia/ai-chat-ui": "1.52.0",
     "@theia/ai-code-completion": "1.52.0",
+    "@theia/ai-code-fix": "1.52.0",
     "@theia/ai-core": "1.52.0",
     "@theia/ai-history": "1.52.0",
     "@theia/ai-history-ui": "1.52.0",

--- a/examples/browser-only/tsconfig.json
+++ b/examples/browser-only/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../packages/ai-code-completion"
     },
     {
+      "path": "../../packages/ai-code-fix"
+    },
+    {
       "path": "../../packages/ai-core"
     },
     {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -23,6 +23,7 @@
     "@theia/ai-chat": "1.52.0",
     "@theia/ai-chat-ui": "1.52.0",
     "@theia/ai-code-completion": "1.52.0",
+    "@theia/ai-code-fix": "1.52.0",
     "@theia/ai-core": "1.52.0",
     "@theia/ai-history": "1.52.0",
     "@theia/ai-history-ui": "1.52.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../packages/ai-code-completion"
     },
     {
+      "path": "../../packages/ai-code-fix"
+    },
+    {
       "path": "../../packages/ai-core"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -29,6 +29,7 @@
     "@theia/ai-chat": "1.52.0",
     "@theia/ai-chat-ui": "1.52.0",
     "@theia/ai-code-completion": "1.52.0",
+    "@theia/ai-code-fix": "1.52.0",
     "@theia/ai-core": "1.52.0",
     "@theia/ai-history": "1.52.0",
     "@theia/ai-history-ui": "1.52.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../packages/ai-code-completion"
     },
     {
+      "path": "../../packages/ai-code-fix"
+    },
+    {
       "path": "../../packages/ai-core"
     },
     {

--- a/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
@@ -30,7 +30,7 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
 
     private disposable: monaco.IDisposable | undefined;
 
-    onStart(): void {
+    onDidInitializeLayout(): void {
         const enableCodeCompletion = this.preferenceService.get<boolean>('ai-code-completion.enable', false);
         if (enableCodeCompletion) {
             this.disposable = monaco.languages.registerCompletionItemProvider({ scheme: 'file' }, this.codeCompletionProvider);

--- a/packages/ai-code-fix/.eslintrc.js
+++ b/packages/ai-code-fix/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-code-fix/README.md
+++ b/packages/ai-code-fix/README.md
@@ -1,0 +1,30 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - AI Code Completion</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/ai-code-completion` extension contributes Ai based code completion.
+
+## Additional Information
+
+<!-- - [API documentation for `@theia/navigator`](https://eclipse-theia.github.io/theia/docs/next/modules/navigator.html) -->
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/ai-code-fix/README.md
+++ b/packages/ai-code-fix/README.md
@@ -4,7 +4,7 @@
 
 <img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
 
-<h2>ECLIPSE THEIA - AI Code Completion</h2>
+<h2>ECLIPSE THEIA - AI Code Fixes</h2>
 
 <hr />
 
@@ -12,11 +12,10 @@
 
 ## Description
 
-The `@theia/ai-code-completion` extension contributes Ai based code completion.
+The `@theia/ai-code-fix` extension contributes AI-based quick-fixing.
 
 ## Additional Information
 
-<!-- - [API documentation for `@theia/navigator`](https://eclipse-theia.github.io/theia/docs/next/modules/navigator.html) -->
 - [Theia - GitHub](https://github.com/eclipse-theia/theia)
 - [Theia - Website](https://theia-ide.org/)
 

--- a/packages/ai-code-fix/package.json
+++ b/packages/ai-code-fix/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@theia/ai-code-fix",
+  "version": "1.52.0",
+  "description": "Theia - AI Fix",
+  "dependencies": {
+    "@theia/ai-core": "1.52.0",
+    "@theia/core": "1.52.0",
+    "@theia/filesystem": "1.52.0",
+    "@theia/monaco-editor-core": "1.83.101",
+    "@theia/output": "1.52.0",
+    "@theia/workspace": "1.52.0",
+    "minimatch": "^5.1.0",
+    "tslib": "^2.6.2"
+  },
+  "main": "lib/common",
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/ai-code-fix-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.52.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-code-fix/src/browser/ai-code-fix-frontend-application-contribution.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-fix-frontend-application-contribution.ts
@@ -33,8 +33,8 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
     private disposable: monaco.IDisposable | undefined;
 
     onDidInitializeLayout(): void {
-        const enableCodeCompletion = this.preferenceService.get<boolean>(AICodeFixPrefs.ENABLED, false);
-        if (enableCodeCompletion) {
+        const enableCodeFixing = this.preferenceService.get<boolean>(AICodeFixPrefs.ENABLED, false);
+        if (enableCodeFixing) {
             const disposeCommand = monaco.editor.registerCommand(AI_CODE_FIX_COMMAND_ID, (_accessor, ...args) => {
                 const arg = args[0];
                 const newText: string = arg.newText;

--- a/packages/ai-code-fix/src/browser/ai-code-fix-frontend-module.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-fix-frontend-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CodeFixAgent, CodeFixAgentImpl } from './code-fix-agent';
 import { AICodeFixProvider } from './ai-code-fix-provider';
-import { AIFrontendApplicationContribution } from './ai-code-frontend-application-contribution';
+import { AIFrontendApplicationContribution } from './ai-code-fix-frontend-application-contribution';
 import { FrontendApplicationContribution, PreferenceContribution } from '@theia/core/lib/browser';
 import { Agent } from '@theia/ai-core';
 import { AICodeFixPreferencesSchema } from './ai-code-fix-preference';

--- a/packages/ai-code-fix/src/browser/ai-code-fix-frontend-module.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-fix-frontend-module.ts
@@ -1,0 +1,32 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { CodeFixAgent, CodeFixAgentImpl } from './code-fix-agent';
+import { AICodeFixProvider } from './ai-code-fix-provider';
+import { AIFrontendApplicationContribution } from './ai-code-frontend-application-contribution';
+import { FrontendApplicationContribution, PreferenceContribution } from '@theia/core/lib/browser';
+import { Agent } from '@theia/ai-core';
+import { AICodeFixPreferencesSchema } from './ai-code-fix-preference';
+
+export default new ContainerModule(bind => {
+    bind(CodeFixAgentImpl).toSelf().inSingletonScope();
+    bind(CodeFixAgent).toService(CodeFixAgentImpl);
+    bind(Agent).toService(CodeFixAgentImpl);
+    bind(AICodeFixProvider).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).to(AIFrontendApplicationContribution).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({ schema: AICodeFixPreferencesSchema });
+});

--- a/packages/ai-code-fix/src/browser/ai-code-fix-preference.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-fix-preference.ts
@@ -1,0 +1,32 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+
+export namespace AICodeFixPrefs {
+    export const ENABLED = 'AI Code Fixing';
+}
+
+export const AICodeFixPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [AICodeFixPrefs.ENABLED]: {
+            type: 'boolean',
+            description: 'Enable AI code fixing',
+            default: false
+        }
+    }
+};

--- a/packages/ai-code-fix/src/browser/ai-code-fix-provider.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-fix-provider.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as monaco from '@theia/monaco-editor-core';
+
+import { CodeFixAgent } from './code-fix-agent';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { PreferenceService } from '@theia/core/lib/browser';
+import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
+import { CodeActionContext } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneLanguages';
+
+@injectable()
+export class AICodeFixProvider implements monaco.languages.CodeActionProvider {
+
+    @inject(CodeFixAgent)
+    protected readonly agent: CodeFixAgent;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    constructor() {
+    }
+
+    async provideCodeActions(model: monaco.editor.ITextModel & ITextModel,
+        range: monaco.Range,
+        context: monaco.languages.CodeActionContext & CodeActionContext,
+        token: monaco.CancellationToken):
+        Promise<monaco.languages.CodeActionList | undefined> {
+        const codeActions = [];
+        for (const marker of (context as monaco.languages.CodeActionContext).markers) {
+            if (range.startLineNumber === marker.startLineNumber) {
+                codeActions.push(...(await this.agent.provideQuickFix(model, marker, context, token)));
+            }
+        }
+        return { actions: codeActions, dispose: () => { } };
+    }
+    resolveCodeAction?(codeAction: monaco.languages.CodeAction, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CodeAction> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/packages/ai-code-fix/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-frontend-application-contribution.ts
@@ -19,7 +19,6 @@ import { FrontendApplicationContribution, PreferenceService } from '@theia/core/
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AICodeFixProvider } from './ai-code-fix-provider';
 import { AICodeFixPrefs } from './ai-code-fix-preference';
-import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
 
 const AI_CODE_FIX_COMMAND_ID = 'ai-code-fix';
 
@@ -36,12 +35,11 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
     onDidInitializeLayout(): void {
         const enableCodeCompletion = this.preferenceService.get<boolean>(AICodeFixPrefs.ENABLED, false);
         if (enableCodeCompletion) {
-            const disposeCommand = monaco.editor.registerCommand(AI_CODE_FIX_COMMAND_ID, (accessor, ...args) => {
+            const disposeCommand = monaco.editor.registerCommand(AI_CODE_FIX_COMMAND_ID, (_accessor, ...args) => {
                 const arg = args[0];
                 const newText: string = arg.newText;
-                const model: ITextModel = arg.model;
                 const editor: monaco.editor.ICodeEditor = arg.editor;
-                const range = model.getFullModelRange();
+                const range = arg.range;
                 const command = {
                     identifier: AI_CODE_FIX_COMMAND_ID,
                     range,

--- a/packages/ai-code-fix/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-fix/src/browser/ai-code-frontend-application-contribution.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as monaco from '@theia/monaco-editor-core';
+import { FrontendApplicationContribution, PreferenceService } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { AICodeFixProvider } from './ai-code-fix-provider';
+import { AICodeFixPrefs } from './ai-code-fix-preference';
+
+@injectable()
+export class AIFrontendApplicationContribution implements FrontendApplicationContribution {
+    @inject(AICodeFixProvider)
+    private codeFixProvider: AICodeFixProvider;
+
+    @inject(PreferenceService)
+    private readonly preferenceService: PreferenceService;
+
+    private disposable: monaco.IDisposable | undefined;
+
+    onDidInitializeLayout(): void {
+        const enableCodeCompletion = this.preferenceService.get<boolean>(AICodeFixPrefs.ENABLED, false);
+        if (enableCodeCompletion) {
+            this.disposable = monaco.languages.registerCodeActionProvider({ scheme: 'file' }, (this.codeFixProvider as monaco.languages.CodeActionProvider));
+        }
+        this.preferenceService.onPreferenceChanged(event => {
+            if (event.preferenceName === AICodeFixPrefs.ENABLED) {
+                if (this.disposable) {
+                    this.disposable.dispose();
+                    this.disposable = undefined;
+                }
+                if (event.newValue) {
+                    this.disposable = monaco.languages.registerCodeActionProvider({ scheme: 'file' }, (this.codeFixProvider as monaco.languages.CodeActionProvider));
+                }
+            }
+        });
+    }
+
+    onStop(): void {
+    }
+}

--- a/packages/ai-code-fix/src/browser/code-fix-agent.ts
+++ b/packages/ai-code-fix/src/browser/code-fix-agent.ts
@@ -56,6 +56,11 @@ export class CodeFixAgentImpl implements CodeFixAgent {
         const language = model.getLanguageId();
         const errorMsg = marker.message;
         const lineNumber = marker.startLineNumber;
+        const editor = monaco.editor.getEditors().find(ed => ed.getModel() === model);
+        if (!editor) {
+            console.error('No editor found for code-fix-agent');
+            return [];
+        }
 
         const prompt = await this.promptService.getPrompt('code-fix-prompt', { fileContent, file: fileName, language, errorMsg: errorMsg, lineNumber: lineNumber });
         if (!prompt) {
@@ -71,16 +76,11 @@ export class CodeFixAgentImpl implements CodeFixAgent {
         return [
             {
                 title: 'AI QuickFix',
-                edit: {
-                    edits: [{
-                        resource: model.uri,
-                        textEdit: {
-                            range: model.getFullModelRange(),
-                            text: fixText
-                        },
-                        versionId: undefined
-                    }]
-                }
+                command: {
+                    id: 'ai-code-fix',
+                    title: 'AI Code Fix',
+                    arguments: [{ model, editor, newText: fixText }]
+                },
             }];
 
     };

--- a/packages/ai-code-fix/src/browser/code-fix-agent.ts
+++ b/packages/ai-code-fix/src/browser/code-fix-agent.ts
@@ -1,0 +1,109 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as monaco from '@theia/monaco-editor-core';
+import { Agent, getTextOfResponse, LanguageModelRegistry, LanguageModelSelector, PromptService, PromptTemplate } from '@theia/ai-core/lib/common';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
+import { CodeActionContext } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneLanguages';
+
+export const CodeFixAgent = Symbol('CodeFixAgent');
+export interface CodeFixAgent extends Agent {
+    provideQuickFix(model: monaco.editor.ITextModel, marker: monaco.editor.IMarkerData,
+        context: monaco.languages.CodeActionContext & CodeActionContext, token: monaco.CancellationToken): Promise<monaco.languages.CodeAction[]>;
+}
+
+@injectable()
+export class CodeFixAgentImpl implements CodeFixAgent {
+    variables: string[];
+
+    @inject(LanguageModelRegistry)
+    protected languageModelRegistry: LanguageModelRegistry;
+
+    @inject(PromptService)
+    protected promptService: PromptService;
+
+    async provideQuickFix(model: monaco.editor.ITextModel & ITextModel, marker: monaco.editor.IMarkerData,
+        context: monaco.languages.CodeActionContext & CodeActionContext, token: monaco.CancellationToken): Promise<monaco.languages.CodeAction[]> {
+
+        const languageModels = await this.languageModelRegistry.selectLanguageModels({
+            agent: 'code-fix-agent',
+            purpose: 'code-fix',
+            identifier: 'openai/gpt-4o'
+        });
+        if (languageModels.length === 0) {
+            console.error('No language model found for code-fix-agent');
+            return [];
+        }
+        const languageModel = languageModels[0];
+        console.log('Code fix agent is using language model:', languageModel.id);
+
+        const fileContent = model.getValue();
+        const fileName = model.uri.toString(false);
+        const language = model.getLanguageId();
+        const errorMsg = marker.message;
+        const lineNumber = marker.startLineNumber;
+
+        const prompt = await this.promptService.getPrompt('code-fix-prompt', { fileContent, file: fileName, language, errorMsg: errorMsg, lineNumber: lineNumber });
+        if (!prompt) {
+            console.error('No prompt found for code-fix-agent');
+            return [];
+        }
+        console.log('Code fix agent is using prompt:', prompt);
+
+        const response = await languageModel.request(({ messages: [{ type: 'text', actor: 'user', query: prompt }] }));
+        const fixText = await getTextOfResponse(response);
+        console.log('Code fix agent suggests', fixText);
+
+        return [
+            {
+                title: 'AI QuickFix',
+                edit: {
+                    edits: [{
+                        resource: model.uri,
+                        textEdit: {
+                            range: model.getFullModelRange(),
+                            text: fixText
+                        },
+                        versionId: undefined
+                    }]
+                }
+            }];
+
+    };
+    id: string = 'code-fix-agent';
+    name: string = 'Code Fix Agent';
+    description: string = 'This agent provides fixes for problem markers';
+    promptTemplates: PromptTemplate[] = [
+        {
+            id: 'code-fix-prompt',
+            template: `
+            You are a code fixing agent. The current file you have to fix is named \${file}.
+            The language of the file is \${language}. Return your result as plain text without markdown formatting.
+            Provide a corrected version of the following code. 
+
+            \${fileContent}
+
+            The error is reported on line number \${lineNumber} and the error message is \${errorMsg}.
+            Provide the full content of the file.
+            `,
+        }
+    ];
+    languageModelRequirements: Omit<LanguageModelSelector, 'agent'>[] = [{
+        purpose: 'code-fix',
+        identifier: 'openai/gpt-4o'
+    }];
+}

--- a/packages/ai-code-fix/src/browser/index.ts
+++ b/packages/ai-code-fix/src/browser/index.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './ai-code-fix-provider';
+export * from './code-fix-agent';

--- a/packages/ai-code-fix/tsconfig.json
+++ b/packages/ai-code-fix/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../filesystem"
+    },
+    {
+      "path": "../output"
+    },
+    {
+      "path": "../workspace"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,9 @@
       "path": "packages/ai-code-completion"
     },
     {
+      "path": "packages/ai-code-fix"
+    },
+    {
       "path": "packages/ai-core"
     },
     {


### PR DESCRIPTION
#### What it does

A very basic prototype of a Monaco `CodeActionProvider` for AI quick fixes.

Addresses parts of eclipsesource/osweek-2024#29

![demo](https://github.com/user-attachments/assets/9972ffad-75cb-4d06-a4cc-0f48c12fcbf7)

#### How to test

Manifest some kind of problem, identified in the Monaco editor by a problem marker, in a source file of your choice in a language of your choice. So long as that choice is implemented in a Monaco editor with a suitable language server.

Summon quick fixes on the problem using `Ctrl+.` (or `Cmd+.` on Mac).

Select the "AI Quick Fix" option.

Bask in the glory of a corrected source code.

#### Follow-ups

* Trigger chat from problem marker
* Support AI Quick Fix in the Problems view
* Handle rate-limiting of a remote AI service (do we do that somewhere in the framework already?)
* Distinguish between no useful response and connection error
* Cache requests to avoid sending the same request over and over again for markers
* format on AI quick-fix

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
