### PR TITLE
Default chat agent does not use prompt templates

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -19,7 +19,7 @@
  *--------------------------------------------------------------------------------------------*/
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatAgents.ts
 
-import { CommunicationRecordingService, LanguageModel, LanguageModelResponse, LanguageModelRequirement } from '@theia/ai-core';
+import { CommunicationRecordingService, LanguageModel, LanguageModelResponse, LanguageModelRequirement, PromptService } from '@theia/ai-core';
 import {
     Agent,
     isLanguageModelStreamResponse,
@@ -32,6 +32,7 @@ import { generateUuid, ILogger, isArray } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatModel, ChatRequestModelImpl, ChatResponseContent, CodeChatResponseContentImpl, MarkdownChatResponseContentImpl, ToolCallResponseContentImpl } from './chat-model';
 import { ChatMessage } from './chat-util';
+import { defaultTemplate } from './default-template';
 
 export enum ChatAgentLocation {
     Panel = 'panel',
@@ -74,12 +75,15 @@ export class DefaultChatAgent implements ChatAgent {
     @inject(CommunicationRecordingService)
     protected recordingService: CommunicationRecordingService;
 
+    @inject(PromptService)
+    protected promptService: PromptService;
+
     id: string = 'DefaultChatAgent';
     name: string = 'DefaultChatAgent';
     iconClass = 'codicon codicon-copilot';
     description: string = 'The default chat agent provided by Theia.';
     variables: string[] = [TODAY_VARIABLE.id];
-    promptTemplates: PromptTemplate[] = [];
+    promptTemplates: PromptTemplate[] = [defaultTemplate];
     // FIXME: placeholder values
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat',
@@ -239,7 +243,7 @@ export class DefaultChatAgent implements ChatAgent {
     }
 
     protected async getSystemMessage(): Promise<string | undefined> {
-        return undefined;
+        return this.promptService.getPrompt(defaultTemplate.id);
     }
 
     private parse(token: LanguageModelStreamResponsePart, previousContent: ChatResponseContent[]): ChatResponseContent | ChatResponseContent[] {

--- a/packages/ai-chat/src/common/default-template.ts
+++ b/packages/ai-chat/src/common/default-template.ts
@@ -1,0 +1,21 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { PromptTemplate } from '@theia/ai-core';
+
+export const defaultTemplate: PromptTemplate = {
+    id: 'default-template',
+    template: 'You are an AI Assistant for software developers, running inside of Eclipse Theia'
+};

--- a/packages/ai-theia-agents/src/browser/workspace-agent.ts
+++ b/packages/ai-theia-agents/src/browser/workspace-agent.ts
@@ -16,7 +16,7 @@
 import { ChatAgent, ChatMessage, ChatRequestParser, DefaultChatAgent } from '@theia/ai-chat/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { template } from '../common/template';
-import { LanguageModel, LanguageModelResponse, PromptService, ToolRequest } from '@theia/ai-core';
+import { LanguageModel, LanguageModelResponse, ToolRequest } from '@theia/ai-core';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core';
@@ -28,9 +28,6 @@ export class TheiaWorkspaceAgent extends DefaultChatAgent implements ChatAgent {
     override name = 'Workspace Agent';
     override description = 'An AI Agent that can access the current Theia Workspace contents';
     override promptTemplates = [template];
-
-    @inject(PromptService)
-    protected promptService: PromptService;
 
     @inject(ChatRequestParser)
     protected chatRequestParser: ChatRequestParser;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- add a default template that the Default Chat Agent can use

#### How to test

- use the AI Chat and ask questions (e.g. "Who are you?"
- open AI Configuration view and edit the Default Agent Template
- changes to the default template should be taken into account when chatting with the Default Agent
