### PR TITLE
Support auto-scrolling the chat window

### DIFF
--- a/packages/ai-chat-ui/src/browser/aichat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/aichat-ui-contribution.ts
@@ -14,11 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-// import { ChatWidget } from './chat-widget';
+import { injectable } from '@theia/core/shared/inversify';
+import { CommandRegistry } from '@theia/core';
+import { Widget } from '@theia/core/lib/browser';
+import { ChatCommands } from './chat-view-commands';
 import { ChatViewWidget } from './chat-view-widget';
+
 export const AI_CHAT_TOGGLE_COMMAND_ID = 'aiChat:toggle';
+
 @injectable()
 export class AIChatContribution extends AbstractViewContribution<ChatViewWidget> {
 
@@ -33,5 +37,31 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             toggleCommandId: AI_CHAT_TOGGLE_COMMAND_ID,
             toggleKeybinding: 'ctrlcmd+shift+e'
         });
+    }
+
+    override registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(ChatCommands.LOCK__WIDGET, {
+            isEnabled: widget => this.withWidget(widget, chatWidget => !chatWidget.isLocked),
+            isVisible: widget => this.withWidget(widget, chatWidget => !chatWidget.isLocked),
+            execute: widget => this.withWidget(widget, chatWidget => {
+                chatWidget.lock();
+                return true;
+            })
+        });
+        registry.registerCommand(ChatCommands.UNLOCK__WIDGET, {
+            isEnabled: widget => this.withWidget(widget, chatWidget => chatWidget.isLocked),
+            isVisible: widget => this.withWidget(widget, chatWidget => chatWidget.isLocked),
+            execute: widget => this.withWidget(widget, chatWidget => {
+                chatWidget.unlock();
+                return true;
+            })
+        });
+    }
+
+    protected withWidget(
+        widget: Widget | undefined = this.tryGetWidget(),
+        predicate: (output: ChatViewWidget) => boolean = () => true
+    ): boolean | false {
+        return widget instanceof ChatViewWidget ? predicate(widget) : false;
     }
 }

--- a/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
@@ -32,6 +32,8 @@ import {
     AIEditorManager, AIEditorSelectionResolver,
     GitHubSelectionResolver, TextFragmentSelectionResolver, TypeDocSymbolSelectionResolver
 } from './chat-response-renderer/ai-editor-manager';
+import { ChatViewWidgetToolbarContribution } from './chat-view-widget-toolbar-contribution';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export default new ContainerModule((bind, _ubind, _isBound, rebind) => {
     bindViewContribution(bind, AIChatContribution);
@@ -72,4 +74,7 @@ export default new ContainerModule((bind, _ubind, _isBound, rebind) => {
     bind(AIEditorSelectionResolver).to(GitHubSelectionResolver).inSingletonScope();
     bind(AIEditorSelectionResolver).to(TypeDocSymbolSelectionResolver).inSingletonScope();
     bind(AIEditorSelectionResolver).to(TextFragmentSelectionResolver).inSingletonScope();
+
+    bind(ChatViewWidgetToolbarContribution).toSelf().inSingletonScope();
+    bind(TabBarToolbarContribution).toService(ChatViewWidgetToolbarContribution);
 });

--- a/packages/ai-chat-ui/src/browser/chat-view-commands.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-commands.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, nls } from '@theia/core';
+import { codicon } from '@theia/core/lib/browser';
+
+export namespace ChatCommands {
+    const CHAT_CATEGORY = 'Chat';
+    const CHAT_CATEGORY_KEY = nls.getDefaultKey(CHAT_CATEGORY);
+
+    export const LOCK__WIDGET = Command.toLocalizedCommand({
+        id: 'chat:widget:lock',
+        category: CHAT_CATEGORY,
+        iconClass: codicon('unlock')
+    }, '', CHAT_CATEGORY_KEY);
+
+    export const UNLOCK__WIDGET = Command.toLocalizedCommand({
+        id: 'chat:widget:unlock',
+        category: CHAT_CATEGORY,
+        iconClass: codicon('lock')
+    }, '', CHAT_CATEGORY_KEY);
+}

--- a/packages/ai-chat-ui/src/browser/chat-view-widget-toolbar-contribution.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget-toolbar-contribution.tsx
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { AIChatContribution } from './aichat-ui-contribution';
+import { Emitter, nls } from '@theia/core';
+import { ChatCommands } from './chat-view-commands';
+
+@injectable()
+export class ChatViewWidgetToolbarContribution implements TabBarToolbarContribution {
+    @inject(AIChatContribution)
+    protected readonly chatContribution: AIChatContribution;
+
+    protected readonly onChatWidgetStateChangedEmitter = new Emitter<void>();
+    protected readonly onChatWidgetStateChanged = this.onChatWidgetStateChangedEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        this.chatContribution.widget.then(widget => {
+            widget.onStateChanged(() => this.onChatWidgetStateChangedEmitter.fire());
+        });
+    }
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: ChatCommands.LOCK__WIDGET.id,
+            command: ChatCommands.LOCK__WIDGET.id,
+            tooltip: nls.localizeByDefault('Turn Auto Scrolling Off'),
+            onDidChange: this.onChatWidgetStateChanged,
+            priority: 2
+        });
+        registry.registerItem({
+            id: ChatCommands.UNLOCK__WIDGET.id,
+            command: ChatCommands.UNLOCK__WIDGET.id,
+            tooltip: nls.localizeByDefault('Turn Auto Scrolling On'),
+            onDidChange: this.onChatWidgetStateChanged,
+            priority: 2
+        });
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -13,16 +13,22 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { BaseWidget, codicon, Message, PanelLayout } from '@theia/core/lib/browser';
+import { BaseWidget, codicon, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { nls } from '@theia/core/lib/common/nls';
 import { ChatViewTreeWidget } from './chat-tree-view/chat-view-tree-widget';
 import { ChatInputWidget } from './chat-input-widget';
 import { ChatModel, ChatRequest, ChatService } from '@theia/ai-chat';
-import { ILogger } from '@theia/core';
+import { deepClone, Event, Emitter, ILogger } from '@theia/core';
+
+export namespace ChatViewWidget {
+    export interface State {
+        locked?: boolean;
+    }
+}
 
 @injectable()
-export class ChatViewWidget extends BaseWidget {
+export class ChatViewWidget extends BaseWidget implements StatefulWidget {
 
     public static ID = 'chat-view-widget';
     static LABEL = nls.localizeByDefault('Chat');
@@ -35,6 +41,9 @@ export class ChatViewWidget extends BaseWidget {
 
     // TODO: handle multiple sessions
     private chatModel: ChatModel;
+
+    protected _state: ChatViewWidget.State = { locked: false };
+    protected readonly onStateChangedEmitter = new Emitter<ChatViewWidget.State>();
 
     constructor(
         @inject(ChatViewTreeWidget)
@@ -56,6 +65,10 @@ export class ChatViewWidget extends BaseWidget {
         this.toDispose.pushAll([
             this.treeWidget,
             this.inputWidget,
+            this.onStateChanged(newState => {
+                this.treeWidget.shouldScrollToEnd = !newState.locked;
+                this.update();
+            })
         ]);
         const layout = this.layout = new PanelLayout();
         this.treeWidget.node.classList.add('chat-tree-view-widget');
@@ -66,6 +79,31 @@ export class ChatViewWidget extends BaseWidget {
         // TODO restore sessions if needed
         this.chatModel = this.chatService.createSession();
         this.treeWidget.trackChatModel(this.chatModel);
+    }
+
+    storeState(): object {
+        return this.state;
+    }
+
+    restoreState(oldState: object & Partial<ChatViewWidget.State>): void {
+        const copy = deepClone(this.state);
+        if (oldState.locked) {
+            copy.locked = oldState.locked;
+        }
+        this.state = copy;
+    }
+
+    protected get state(): ChatViewWidget.State {
+        return this._state;
+    }
+
+    protected set state(state: ChatViewWidget.State) {
+        this._state = state;
+        this.onStateChangedEmitter.fire(this._state);
+    }
+
+    get onStateChanged(): Event<ChatViewWidget.State> {
+        return this.onStateChangedEmitter.event;
     }
 
     protected override onAfterAttach(msg: Message): void {
@@ -87,4 +125,15 @@ export class ChatViewWidget extends BaseWidget {
         // Tree Widget currently tracks the ChatModel itself. Therefore no notification necessary.
     }
 
+    lock(): void {
+        this.state = { ...deepClone(this.state), locked: true };
+    }
+
+    unlock(): void {
+        this.state = { ...deepClone(this.state), locked: false };
+    }
+
+    get isLocked(): boolean {
+        return !!this.state.locked;
+    }
 }

--- a/packages/ai-core/src/browser/ai-settings-service.ts
+++ b/packages/ai-core/src/browser/ai-settings-service.ts
@@ -17,7 +17,7 @@ import { DisposableCollection, Emitter, Event } from '@theia/core';
 import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
 import { JSONObject } from '@theia/core/shared/@phosphor/coreutils';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { LanguageModelRequirement } from '../common';
+import { LanguageModelSelector } from '../common';
 
 @injectable()
 export class AISettingsService {

--- a/packages/ai-core/src/browser/ai-settings-service.ts
+++ b/packages/ai-core/src/browser/ai-settings-service.ts
@@ -17,7 +17,7 @@ import { DisposableCollection, Emitter, Event } from '@theia/core';
 import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
 import { JSONObject } from '@theia/core/shared/@phosphor/coreutils';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { LanguageModelSelector } from '../common';
+import { LanguageModelRequirement } from '../common';
 
 @injectable()
 export class AISettingsService {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Allow user to lock auto-scroll on chat window toolbar
- Persist lock state during reloads

Fixes https://github.com/eclipsesource/osweek-2024/issues/62

#### How to test

- Use toolbar icon to lock or unlock the auto scrolling in the chat feature. If unlocked (default) the window should autoscroll to the bottom of the last message. If locked, it shouldn't scroll anymore.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
