### PR TITLE
Delegating default chat agent

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -208,7 +208,16 @@ export class ChatViewTreeWidget extends TreeWidget {
         }
 
         const agent = node.response.agentId ? this.chatAgentService.getAgent(node.response.agentId) : undefined;
-        return agent?.name ?? 'AI';
+        const initialAgentlabel = agent?.name ?? 'AI';
+        const labelParts = [initialAgentlabel];
+
+        for (const delegateAgentId of node.response.delegateAgentIds) {
+            const delegateAgent = this.chatAgentService.getAgent(delegateAgentId);
+            const delegateAgentlabel = delegateAgent?.name ?? 'AI';
+            labelParts.push(delegateAgentlabel);
+        }
+
+        return labelParts.join(' > ');
     }
     private getAgentIconClassName(node: RequestNode | ResponseNode): string | undefined {
         if (isRequestNode(node)) {

--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -24,10 +24,10 @@ import {
     ChatRequestParser,
     ChatRequestParserImpl,
     ChatService,
-    ChatServiceImpl,
-    DefaultChatAgent
+    ChatServiceImpl
 } from '../common';
 import { CommandChatAgent } from '../common/command-chat-agents';
+import { DelegatingDefaultChatAgent } from '../common/delegating-default-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -42,9 +42,9 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    bind(DefaultChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(DefaultChatAgent);
-    bind(ChatAgent).toService(DefaultChatAgent);
+    bind(DelegatingDefaultChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(DelegatingDefaultChatAgent);
+    bind(ChatAgent).toService(DelegatingDefaultChatAgent);
 
     bind(CommandChatAgent).toSelf().inSingletonScope();
     bind(Agent).toService(CommandChatAgent);

--- a/packages/ai-chat/src/common/chat-agent-service.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.ts
@@ -57,6 +57,6 @@ export class ChatAgentServiceImpl implements ChatAgentService {
         if (!agent) {
             throw new Error(`Agent ${agentId} not found`);
         }
-        return agent.invoke(request);
+        return agent.invoke(request, this);
     }
 }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -74,6 +74,8 @@ export interface ChatRequestModel {
     readonly response: ChatResponseModel;
     readonly message: ParsedChatRequest;
     readonly agentId?: string;
+    readonly delegateAgentIds: string[];
+    addDelegate(delegateAgentid: string): void;
 }
 
 export interface ChatProgressMessage {
@@ -225,7 +227,9 @@ export interface ChatResponseModel {
     readonly response: ChatResponse;
     readonly isComplete: boolean;
     readonly isCanceled: boolean;
-    readonly agentId?: string;
+    readonly agentId?: string
+    readonly delegateAgentIds: string[];
+    addDelegate(delegateAgentid: string): void;
     cancel(): void;
 }
 
@@ -275,6 +279,7 @@ export class ChatRequestModelImpl implements ChatRequestModel {
     protected _request: ChatRequest;
     protected _response: ChatResponseModelImpl;
     protected _agentId?: string;
+    protected _delegateAgentIds: string[];
 
     constructor(session: ChatModel, public readonly message: ParsedChatRequest, agentId?: string) {
         // TODO accept serialized data as a parameter to restore a previously saved ChatRequestModel
@@ -283,6 +288,7 @@ export class ChatRequestModelImpl implements ChatRequestModel {
         this._session = session;
         this._response = new ChatResponseModelImpl(this._id, agentId);
         this._agentId = agentId;
+        this._delegateAgentIds = [];
     }
 
     get id(): string {
@@ -303,6 +309,15 @@ export class ChatRequestModelImpl implements ChatRequestModel {
 
     get agentId(): string | undefined {
         return this._agentId;
+    }
+
+    get delegateAgentIds(): string[] {
+        return this._delegateAgentIds;
+    }
+
+    addDelegate(delegateAgentid: string): void {
+        this._delegateAgentIds.push(delegateAgentid);
+        this._response.addDelegate(delegateAgentid);
     }
 
 }
@@ -575,6 +590,7 @@ class ChatResponseModelImpl implements ChatResponseModel {
     protected _isComplete: boolean;
     protected _isCanceled: boolean;
     protected _agentId?: string;
+    protected _delegateAgentIds: string[];
 
     constructor(requestId: string, agentId?: string) {
         // TODO accept serialized data as a parameter to restore a previously saved ChatResponseModel
@@ -587,6 +603,7 @@ class ChatResponseModelImpl implements ChatResponseModel {
         this._isComplete = false;
         this._isCanceled = false;
         this._agentId = agentId;
+        this._delegateAgentIds = [];
     }
 
     get id(): string {
@@ -615,6 +632,14 @@ class ChatResponseModelImpl implements ChatResponseModel {
 
     get agentId(): string | undefined {
         return this._agentId;
+    }
+
+    get delegateAgentIds(): string[] {
+        return this._delegateAgentIds;
+    }
+
+    addDelegate(delegateAgentid: string): void {
+        this._delegateAgentIds.push(delegateAgentid);
     }
 
     complete(): void {

--- a/packages/ai-chat/src/common/command-chat-agents.ts
+++ b/packages/ai-chat/src/common/command-chat-agents.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { AbstractTextToModelParsingChatAgent, ChatAgentLocation } from './chat-agents';
+import { AbstractTextToModelParsingChatAgent } from './chat-agents';
 import {
     PromptTemplate,
     LanguageModelRequirement
@@ -258,15 +258,16 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
 
     id: string = 'CommandChatAgent';
     name: string = 'CommandChatAgent';
-    description: string = 'The default chat agent provided by Theia responsible for providing commands.';
+    description: string = 'This agent knows everything about Theia commands you can run within the IDE.';
     variables: string[] = [];
     promptTemplates: PromptTemplate[] = [new CommandChatAgentSystemPromptTemplate()];
+
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'command',
         identifier: 'openai/gpt-4o',
     }];
-    locations: ChatAgentLocation[] = ChatAgentLocation.ALL;
-    override iconClass?: string | undefined;
+
+    protected override languageModelPurpose = 'command';
 
     protected async getSystemMessage(): Promise<string | undefined> {
         const knownCommands: string[] = [];

--- a/packages/ai-chat/src/common/delegating-default-agent.ts
+++ b/packages/ai-chat/src/common/delegating-default-agent.ts
@@ -1,0 +1,202 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { getJsonOfResponse, LanguageModel, LanguageModelRequirement } from '@theia/ai-core';
+import {
+    PromptTemplate
+} from '@theia/ai-core/lib/common';
+import { injectable } from '@theia/core/shared/inversify';
+import { ChatAgentService } from './chat-agent-service';
+import { AbstractStreamParsingChatAgent } from './chat-agents';
+import { ChatRequestModelImpl } from './chat-model';
+
+export const defaultTemplate: PromptTemplate = {
+    id: 'default-template',
+    template: `# Instructions
+
+You are an AI assistant integrated into the Theia IDE, specifically designed to help software developers by
+providing concise and accurate answers to programming-related questions. Your role is to enhance the
+developer's productivity by offering quick solutions, explanations, and best practices.
+Keep responses short and to the point, focusing on delivering valuable insights, best practices and
+simple solutions.
+
+### Guidelines
+
+1. **Understand Context:**
+   - Assess the context of the code or issue when available.
+   - Tailor responses to be relevant to the programming language, framework, or tools like Eclipse Theia.
+   - Ask clarifying questions if necessary to provide accurate assistance.
+
+2. **Provide Clear Solutions:**
+   - Offer direct answers or code snippets that solve the problem or clarify the concept.
+   - Avoid lengthy explanations unless necessary for understanding.
+
+3. **Promote Best Practices:**
+   - Suggest best practices and common patterns relevant to the question.
+   - Provide links to official documentation for further reading when applicable.
+
+4. **Support Multiple Languages and Tools:**
+   - Be familiar with popular programming languages, frameworks, IDEs like Eclipse Theia, and command-line tools.
+   - Adapt advice based on the language, environment, or tools specified by the developer.
+
+5. **Facilitate Learning:**
+   - Encourage learning by explaining why a solution works or why a particular approach is recommended.
+   - Keep explanations concise and educational.
+
+6. **Maintain Professional Tone:**
+   - Communicate in a friendly, professional manner.
+   - Use technical jargon appropriately, ensuring clarity for the target audience.
+
+7. **Stay on Topic:**
+   - Limit responses strictly to topics related to software development, frameworks, Eclipse Theia, terminal usage, and relevant technologies.
+   - Politely decline to answer questions unrelated to these areas by saying, "I'm here to assist with programming-related questions.
+     For other topics, please refer to a specialized source."
+
+### Example Interactions
+
+- **Question:** "What's the difference between \`let\` and \`var\` in JavaScript?"
+  **Answer:** "\`let\` is block-scoped, while \`var\` is function-scoped. Prefer \`let\` to avoid scope-related bugs."
+
+- **Question:** "How do I handle exceptions in Java?"
+  **Answer:** "Use try-catch blocks: \`\`\`java try { /* code */ } catch (ExceptionType e) { /* handle exception */ }\`\`\`."
+
+- **Question:** "What is the capital of France?"
+  **Answer:** "I'm here to assist with programming-related queries. For other topics, please refer to a specialized source."
+`
+};
+
+export const delegateTemplate: PromptTemplate = {
+    id: 'default-delegate-template',
+    template: `# Instructions
+
+Your task is to identify which Chat Agent(s) should best reply a given user's message.
+You consider all messages of the conversation to ensure consistency and avoid agent switches without a clear context change.
+You should select the best Chat Agent based on the name and description of the agents, matching them to the user message.
+
+## Constraints
+
+Your response must be a JSON array containing the id(s) of the selected Chat Agent(s).
+
+* Do not use ids that are not provided in the list below.
+* Do not include any additional information, explanations, or questions for the user.
+* If there is no suitable choice, pick the \`DefaultChatAgent\`.
+* If there are multiple good choices, select those that are most specific and include them all.
+
+Unless there is a more specific agent available, select the \`DefaultChatAgent\`, especially for general programming-related questions.
+You must only use the \`id\` attribute of the agent, never the name.
+
+## List of Currently Available Chat Agents
+
+\${agents}
+
+`
+};
+
+@injectable()
+export class DelegatingDefaultChatAgent extends AbstractStreamParsingChatAgent {
+
+    id: string = 'DefaultChatAgent';
+    name: string = 'DefaultChatAgent';
+    description: string = 'The default chat agent capable of answering all general programming-related questions.';
+    variables: string[] = [];
+    promptTemplates: PromptTemplate[] = [defaultTemplate, delegateTemplate];
+    languageModelRequirements: LanguageModelRequirement[] = [{
+        purpose: 'chat',
+        identifier: 'openai/gpt-4o',
+    }, {
+        purpose: 'agent-selection',
+        identifier: 'openai/gpt-4o-mini',
+    }];
+
+    protected override languageModelPurpose = 'chat';
+
+    override async invoke(request: ChatRequestModelImpl, chatAgentService?: ChatAgentService): Promise<void> {
+        // check if we should better delegate to a different chat agent
+        let didDelegate = false;
+        const bestChatAgentIds = await this.selectChatAgent(request);
+        for (const agentId of bestChatAgentIds.filter(id => id !== this.id)) {
+            const delegateAgent = chatAgentService?.getAgent(agentId);
+            if (delegateAgent) {
+                request.addDelegate(delegateAgent.id);
+                didDelegate = true;
+                await delegateAgent.invoke(request, chatAgentService);
+            } else {
+                console.warn(`Chat Agent with id ${agentId} is not registered`);
+            }
+        }
+
+        if (didDelegate) {
+            return new Promise<void>(resolve => {
+                request.response.onDidChange(() => {
+                    if (request.response.isComplete) {
+                        resolve();
+                    }
+                });
+            });
+        }
+
+        return super.invoke(request);
+    }
+
+    protected async getAgentSelectionLanguageModel(): Promise<LanguageModel> {
+        return this.selectLanguageModel(this.getAgentSelectionLanguageModelSelector());
+    }
+
+    protected getAgentSelectionLanguageModelSelector(): LanguageModelRequirement {
+        return this.languageModelRequirements.find(req => req.purpose === 'agent-selection')!;
+    }
+
+    protected async getSystemMessage(): Promise<string | undefined> {
+        return this.promptService.getPrompt(defaultTemplate.id);
+    }
+
+    protected async selectChatAgent(request: ChatRequestModelImpl): Promise<string[]> {
+        const delegateSystemPrompt = await this.promptService.getPrompt(delegateTemplate.id);
+        if (delegateSystemPrompt === undefined) {
+            console.warn('No prompt found for delegateTemplate');
+            return [this.id];
+        }
+
+        const messages = await this.getMessages(request.session, false, () => Promise.resolve(delegateSystemPrompt));
+
+        this.recordingService.recordRequest({
+            agentId: this.id,
+            sessionId: request.session.id,
+            timestamp: Date.now(),
+            requestId: request.id,
+            request: request.request.text
+        });
+        const languageModel = await this.getAgentSelectionLanguageModel();
+        const languageModelResponse = await languageModel.request({ messages });
+
+        let agentIds;
+        try {
+            agentIds = await getJsonOfResponse(languageModelResponse) as string[];
+        } catch (e) {
+            agentIds = [this.id];
+        }
+
+        this.recordingService.recordResponse({
+            agentId: this.id,
+            sessionId: request.session.id,
+            timestamp: Date.now(),
+            requestId: request.response.requestId,
+            response: agentIds.join(', ')
+        });
+
+        return agentIds;
+    }
+}

--- a/packages/ai-chat/src/node/agent-backend-module.ts
+++ b/packages/ai-chat/src/node/agent-backend-module.ts
@@ -25,8 +25,8 @@ import {
     ChatRequestParserImpl,
     ChatService,
     ChatServiceImpl,
-    DefaultChatAgent
 } from '../common';
+import { DelegatingDefaultChatAgent } from '../common/delegating-default-agent';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -41,7 +41,7 @@ export default new ContainerModule(bind => {
     bind(ChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(ChatServiceImpl);
 
-    bind(DefaultChatAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(DefaultChatAgent);
-    bind(ChatAgent).toService(DefaultChatAgent);
+    bind(DelegatingDefaultChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(DelegatingDefaultChatAgent);
+    bind(ChatAgent).toService(DelegatingDefaultChatAgent);
 });

--- a/packages/ai-core/src/common/language-model-util.ts
+++ b/packages/ai-core/src/common/language-model-util.ts
@@ -28,3 +28,24 @@ export const getTextOfResponse = async (response: LanguageModelResponse): Promis
     }
     throw new Error(`Invalid response type ${response}`);
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getJsonOfResponse = async (response: LanguageModelResponse): Promise<any> => {
+    const text = await getTextOfResponse(response);
+    if (text.startsWith('```json')) {
+        const regex = /```json\s*([\s\S]*?)\s*```/g;
+        let match;
+        // eslint-disable-next-line no-null/no-null
+        while ((match = regex.exec(text)) !== null) {
+            try {
+                return JSON.parse(match[1]);
+            } catch (error) {
+                console.error('Failed to parse JSON:', error);
+            }
+        }
+    } else if (text.startsWith('{') || text.startsWith('[')) {
+        return JSON.parse(text);
+    }
+    throw new Error('Invalid response format');
+};
+

--- a/packages/ai-pr-finalization/src/browser/ai-pr-finalization-agent.ts
+++ b/packages/ai-pr-finalization/src/browser/ai-pr-finalization-agent.ts
@@ -14,18 +14,18 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { DefaultChatAgent } from '@theia/ai-chat';
+import { AbstractStreamParsingChatAgent } from '@theia/ai-chat';
+import { LanguageModelRequirement } from '@theia/ai-core';
 import { injectable } from '@theia/core/shared/inversify';
 
 @injectable()
-export class AiPRFinalizationAgent extends DefaultChatAgent {
+export class AiPRFinalizationAgent extends AbstractStreamParsingChatAgent {
 
-    override id = 'PrFinalization';
-    override name = 'PRFinalization';
-    override description = `
-        This agent helps users to finish up commits for PRs.`;
-    override variables = [];
-    override promptTemplates = [
+    id = 'PrFinalization';
+    name = 'PRFinalization';
+    description = 'This agent helps users to finish up commits for Pull Requests (PRs).';
+    variables = [];
+    promptTemplates = [
         {
             id: 'ai-pr-finalization:system-prompt',
             name: 'AI PR Finalization System Prompt',
@@ -69,6 +69,13 @@ And here is my git-diff: #git-diff.
 `
         },
     ];
+
+    languageModelRequirements: LanguageModelRequirement[] = [{
+        purpose: 'chat',
+        identifier: 'openai/gpt-4o',
+    }];
+
+    protected override languageModelPurpose = 'chat';
 
     protected override async getSystemMessage(): Promise<string | undefined> {
         return this.promptTemplates.find(template => template.id === 'ai-pr-finalization:system-prompt')?.template;

--- a/packages/ai-workspace-agent/src/browser/workspace-agent.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-agent.ts
@@ -13,18 +13,29 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { ChatAgent, DefaultChatAgent } from '@theia/ai-chat/lib/common';
+import { AbstractStreamParsingChatAgent } from '@theia/ai-chat/lib/common';
+import { FunctionCallRegistry, LanguageModelRequirement, ToolRequest } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { template } from '../common/template';
-import { FunctionCallRegistry, ToolRequest } from '@theia/ai-core';
 import { FileContentFunction, GetWorkspaceFileList } from './functions';
 
 @injectable()
-export class WorkspaceAgent extends DefaultChatAgent implements ChatAgent {
-    override id = 'Workspace';
-    override name = 'Workspace Agent';
-    override description = 'An AI Agent that can access the current Workspace contents';
-    override promptTemplates = [template];
+export class WorkspaceAgent extends AbstractStreamParsingChatAgent {
+    id = 'Workspace';
+    name = 'Workspace Agent';
+    description = `This agent can access the workspace and thus can answer
+questions about projects, project files, and source code in the workspace, such as building the project,
+finding out what this project is about, or how to implement certain aspects of based on the project code.
+`;
+    promptTemplates = [template];
+    override variables = [];
+
+    languageModelRequirements: LanguageModelRequirement[] = [{
+        purpose: 'chat',
+        identifier: 'openai/gpt-4o',
+    }];
+
+    protected override languageModelPurpose = 'chat';
 
     @inject(FunctionCallRegistry)
     protected functionCallRegistry: FunctionCallRegistry;


### PR DESCRIPTION
Issue: https://github.com/eclipsesource/osweek-2024/issues/99

There would be multiple solutions for this regarding who should delegate and how to track this through the code. 
I am open for any suggestions. 
Below PR seems to work as a POC

#### What it does

* add delegation concept for agents to `ChatRequestModel` and `ChatResponseModel`
  * both models have their main `agentId` that is the first agent that is responsible
  * if the agent decides that a different agent should take over, this agent is added to a `delegateAgentIds` property
* if there was delegation, also show this in the UI labels
* add a template to the default chat agent responsible for figuring out the best chat agent to use for the request
* default chat agent delegates to different chat agents if they seem more appropriate for the request
* `ChatAgent.invoke` may also receive the `ChatAgentService` as an optional paramter, so it may delegate. 
  * this service is not injected because this would then be an injection circle. I am open to try other suggestions like `LazyServiceIdentifier`. But this does not seem to be used in the Theia code anywhere. 

![ksnip_20240801-155444](https://github.com/user-attachments/assets/d069943a-704b-47ba-b9bd-4c068597910d)

#### How to test

Tell the default chat agent you want to
* change the theia theme with a command
* finalize a PR
  * following messages should keep the context and should all go to the PR Finalizer until there is a context change
* just chat

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->