### PR TITLE
chat ui input: Use monaco and add autocomplete for agents and variables

### DIFF
--- a/packages/ai-chat-ui/package.json
+++ b/packages/ai-chat-ui/package.json
@@ -4,6 +4,7 @@
   "description": "Theia - AI Chat UI Extension",
   "dependencies": {
     "@theia/ai-chat": "1.52.0",
+    "@theia/ai-core": "1.52.0",
     "@theia/core": "1.52.0",
     "@theia/editor": "1.52.0",
     "@theia/filesystem": "1.52.0",

--- a/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { bindContributionProvider, CommandContribution } from '@theia/core';
-import { bindViewContribution, WidgetFactory, } from '@theia/core/lib/browser';
+import { bindViewContribution, FrontendApplicationContribution, WidgetFactory, } from '@theia/core/lib/browser';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { AIChatCommandContribution } from './ai-chat-command-contribution';
 import { AIChatContribution } from './aichat-ui-contribution';
@@ -36,6 +36,7 @@ import {
 import { ChatViewWidgetToolbarContribution } from './chat-view-widget-toolbar-contribution';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { AIMonacoEditorProvider } from './chat-response-renderer/ai-monaco-editor-provider';
+import { ChatViewLanguageContribution } from './chat-view-language-contribution';
 
 export default new ContainerModule((bind, _ubind, _isBound, rebind) => {
     bindViewContribution(bind, AIChatContribution);
@@ -80,6 +81,9 @@ export default new ContainerModule((bind, _ubind, _isBound, rebind) => {
 
     bind(AIMonacoEditorProvider).toSelf().inSingletonScope();
     rebind(MonacoEditorProvider).toService(AIMonacoEditorProvider);
+
+    bind(FrontendApplicationContribution).to(ChatViewLanguageContribution).inSingletonScope();
+
 });
 
 function bindChatViewWidget(bind: interfaces.Bind): void {

--- a/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
@@ -1,0 +1,119 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import * as monaco from '@theia/monaco-editor-core';
+import { MaybePromise } from '@theia/core';
+import { ProviderResult } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
+import { ChatAgentService } from '@theia/ai-chat';
+import { AIVariableService } from '@theia/ai-core/lib/common';
+
+export const CHAT_VIEW_LANGUAGE_ID = 'ai-chat-view-language';
+export const CHAT_VIEW_LANGUAGE_EXTENSION = 'aichatviewlanguage';
+
+@injectable()
+export class ChatViewLanguageContribution implements FrontendApplicationContribution {
+
+    @inject(ChatAgentService)
+    protected readonly agentService: ChatAgentService;
+
+    @inject(AIVariableService)
+    protected readonly variableService: AIVariableService;
+
+    onStart(_app: FrontendApplication): MaybePromise<void> {
+        console.log('ChatViewLanguageContribution started');
+        monaco.languages.register({ id: CHAT_VIEW_LANGUAGE_ID, extensions: [CHAT_VIEW_LANGUAGE_EXTENSION] });
+
+        monaco.languages.registerCompletionItemProvider(CHAT_VIEW_LANGUAGE_ID, {
+            triggerCharacters: ['@'],
+            provideCompletionItems: (model, position, context, token): ProviderResult<monaco.languages.CompletionList> => this.provideAgentCompletions(model, position),
+        });
+        monaco.languages.registerCompletionItemProvider(CHAT_VIEW_LANGUAGE_ID, {
+            triggerCharacters: ['#'],
+            provideCompletionItems: (model, position, context, token): ProviderResult<monaco.languages.CompletionList> => this.provideVariableCompletions(model, position),
+        });
+    }
+
+    getCompletionRange(model: monaco.editor.ITextModel, position: monaco.Position, triggerCharacter: string): monaco.Range | undefined {
+        // Check if the character before the current position is the trigger character
+        const lineContent = model.getLineContent(position.lineNumber);
+        const characterBefore = lineContent[position.column - 2]; // Get the character before the current position
+
+        if (characterBefore !== triggerCharacter) {
+            // Do not return agent suggestions if the user didn't just type the trigger character
+            return undefined;
+        }
+
+        // Calculate the range from the position of the '@' character
+        const wordInfo = model.getWordUntilPosition(position);
+        return new monaco.Range(
+            position.lineNumber,
+            wordInfo.startColumn,
+            position.lineNumber,
+            position.column
+        );
+    }
+
+    private getSuggestions<T>(
+        model: monaco.editor.ITextModel,
+        position: monaco.Position,
+        triggerChar: string,
+        items: T[],
+        kind: monaco.languages.CompletionItemKind,
+        getId: (item: T) => string,
+        getName: (item: T) => string,
+        getDescription: (item: T) => string
+    ): ProviderResult<monaco.languages.CompletionList> {
+        const completionRange = this.getCompletionRange(model, position, triggerChar);
+        if (completionRange === undefined) {
+            return { suggestions: [] };
+        }
+        const suggestions = items.map(item => ({
+            insertText: getId(item),
+            kind: kind,
+            label: getName(item),
+            range: completionRange,
+            detail: getDescription(item),
+        }));
+        return { suggestions };
+    }
+
+    provideAgentCompletions(model: monaco.editor.ITextModel, position: monaco.Position): ProviderResult<monaco.languages.CompletionList> {
+        return this.getSuggestions(
+            model,
+            position,
+            '@',
+            this.agentService.getAgents(),
+            monaco.languages.CompletionItemKind.Value,
+            agent => agent.id,
+            agent => agent.name,
+            agent => agent.description
+        );
+    }
+
+    provideVariableCompletions(model: monaco.editor.ITextModel, position: monaco.Position): ProviderResult<monaco.languages.CompletionList> {
+        return this.getSuggestions(
+            model,
+            position,
+            '#',
+            this.variableService.getVariables(),
+            monaco.languages.CompletionItemKind.Variable,
+            variable => variable.name,
+            variable => variable.name,
+            variable => variable.description
+        );
+    }
+}

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -104,43 +104,34 @@ div:last-child>.theia-ChatNode {
 }
 
 .chat-input-widget {
-    align-items: center;
-    display: flex;
+  align-items: center;
+  display: flex;
 }
 
-.chat-input-widget>div {
-    width: 100%;
-    padding: 12px 16px;
-    align-items: end;
-    display: flex;
-    gap: 4px;
+.theia-ChatInput {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+  gap: 4px;
 }
 
-.chat-input-widget>div textarea {
-    width: 100%;
-    height: 36px;
-    align-items: flex-end;
-    background-color: var(--theia-input-background);
-    border-radius: 4px;
-    box-sizing: border-box;
-    cursor: text;
-    display: flex;
-    justify-content: space-between;
-    padding: 8px 30px 6px 8px;
-    position: relative;
-    resize: none;
-    overflow: hidden;
-    line-height: 1.3rem;
+.theia-ChatInput-Editor {
+  padding: 10px;
+  resize: none;
+}
+
+.theia-ChatInput-Editor .monaco-editor .margin,
+.theia-ChatInput-Editor .monaco-editor .monaco-editor-background,
+.theia-ChatInput-Editor .monaco-editor .inputarea.ime-input {
+    padding-left: 8px !important;
 }
 
 .theia-ChatInputOptions {
-    height: 23px;
-    padding-bottom: 6px;
-    align-items: center;
-    position: absolute;
-    z-index: 999;
-    right: 20px;
-    display: flex;
+  position: absolute;
+  bottom: 25px;
+  right: 20px;
+  width: 10px;
+  height: 10px;
 }
 
 .theia-ChatInputOptions .option {

--- a/packages/ai-chat-ui/tsconfig.json
+++ b/packages/ai-chat-ui/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../ai-chat"
     },
     {
+      "path": "../ai-core"
+    },
+    {
       "path": "../core"
     },
     {


### PR DESCRIPTION
Implements https://github.com/eclipsesource/osweek-2024/issues/92
Co-authored-by @AlexandraBuzila 

## Changes
Improve the AI chat ui input field with autocompletion for chat agents
and ai variables:

Typing `@` allows to autocomplete chat agents.
Typing `#` allows to autocomplete ai variables.

![agents_vars gif](https://github.com/user-attachments/assets/92231458-a7c5-4d4b-a454-a0fc4a24b3fc)

To facilitate this, the input field was changed from a textarea to an inline monaco editor. A custom language `ai-chat-view-language` is introduced to provide the completions via completion item providers that query the ChatAgentService resp. AIVariableService

## Further changes

Remove obsolete dummy and mock code agents to avoid polluting the auto complete.

## Follow up
 https://github.com/eclipsesource/osweek-2024/issues/106

