### PR TITLE
AI Terminal assistant shows no LLM in AI configuration by default

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -96,9 +96,9 @@ export class DefaultChatAgent implements ChatAgent {
 
     async invoke(request: ChatRequestModelImpl): Promise<void> {
         const selector = this.languageModelRequirements.find(req => req.purpose === 'chat')!;
-        const languageModels = await this.languageModelRegistry.selectLanguageModels({ agent: this.id, ...selector });
-        if (languageModels.length === 0) {
-            throw new Error('Couldn\'t find a language model. Please check your setup!');
+        const languageModel = await this.languageModelRegistry.selectLanguageModel({ agent: this.id, ...selector });
+        if (!languageModel) {
+            throw new Error('Couldn\'t find a matching language model. Please check your setup!');
         }
         const messages = await this.getMessages(request.session);
         this.recordingService.recordRequest({
@@ -110,7 +110,7 @@ export class DefaultChatAgent implements ChatAgent {
             messages
         });
 
-        const languageModelResponse = await this.callLlm(languageModels[0], messages);
+        const languageModelResponse = await this.callLlm(languageModel, messages);
         if (isLanguageModelTextResponse(languageModelResponse)) {
             request.response.response.addContent(
                 new MarkdownChatResponseContentImpl(languageModelResponse.text)

--- a/packages/ai-code-completion/src/common/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/common/code-completion-agent.ts
@@ -44,16 +44,14 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     async provideCompletionItems(model: monaco.editor.ITextModel, position: monaco.Position,
         context: monaco.languages.CompletionContext, token: monaco.CancellationToken): Promise<monaco.languages.CompletionList | undefined> {
 
-        const languageModels = await this.languageModelRegistry.selectLanguageModels({
-            agent: 'code-completion-agent',
-            purpose: 'code-completion',
-            identifier: 'openai/gpt-4o'
+        const languageModel = await this.languageModelRegistry.selectLanguageModel({
+            agent: this.id,
+            ...this.languageModelRequirements[0]
         });
-        if (languageModels.length === 0) {
+        if (!languageModel) {
             console.error('No language model found for code-completion-agent');
             return undefined;
         }
-        const languageModel = languageModels[0];
         console.log('Code completion agent is using language model:', languageModel.id);
 
         // Get text until the given position

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -95,14 +95,14 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                 <span style={{ marginRight: '0.5rem' }}>Variables:</span>
                 <ul className='variable-references'>
                     {agent.variables.map(variableId => <li className='theia-TreeNode theia-CompositeTreeNode theia-ExpandableTreeNode theia-mod-selected'>
-                        <div onClick={() => { this.showVariableConfigurationTab(); }} className='variable-reference'>
+                        <div key={variableId} onClick={() => { this.showVariableConfigurationTab(); }} className='variable-reference'>
                             <span>{variableId}</span>
                             <i className={codicon('chevron-right')}></i>
                         </div></li>)}
                 </ul>
             </div>
             <div className='ai-templates'>
-                {agent.promptTemplates.map(template =>
+                {agent.promptTemplates?.map(template =>
                     <TemplateRenderer
                         key={agent?.id + '.' + template.id}
                         agentId={agent.id}
@@ -113,7 +113,8 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                 <LanguageModelRenderer
                     agent={agent}
                     languageModels={this.languageModels}
-                    aiSettingsService={this.aiSettingsService} />
+                    aiSettingsService={this.aiSettingsService}
+                    languageModelRegistry={this.languageModelRegistry} />
             </div>
         </div>;
     }

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -301,8 +301,11 @@ export class FrontendLanguageModelRegistryImpl
                 return [model];
             }
         }
-
         return this.languageModels.filter(model => isModelMatching(request, model));
+    }
+
+    override async selectLanguageModel(request: LanguageModelSelector): Promise<LanguageModel | undefined> {
+        return (await this.selectLanguageModels(request))[0];
     }
 }
 

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -133,6 +133,7 @@ export interface LanguageModelRegistry {
     getLanguageModels(): Promise<LanguageModel[]>;
     getLanguageModel(id: string): Promise<LanguageModel | undefined>;
     removeLanguageModels(id: string[]): void;
+    selectLanguageModel(request: LanguageModelSelector): Promise<LanguageModel | undefined>;
     selectLanguageModels(request: LanguageModelSelector): Promise<LanguageModel[]>;
 }
 
@@ -204,6 +205,10 @@ export class DefaultLanguageModelRegistryImpl implements LanguageModelRegistry {
         await this.initialized;
         // TODO check for actor and purpose against settings
         return this.languageModels.filter(model => isModelMatching(request, model));
+    }
+
+    async selectLanguageModel(request: LanguageModelSelector): Promise<LanguageModel | undefined> {
+        return (await this.selectLanguageModels(request))[0];
     }
 }
 

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Agent, isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelRegistry, LanguageModelResponse, PromptService } from '@theia/ai-core/lib/common';
+import { Agent, isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelRegistry, LanguageModelRequirement, LanguageModelResponse, PromptService } from '@theia/ai-core/lib/common';
 import { ILogger } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 
@@ -89,10 +89,9 @@ recent-terminal-contents:
 `
         }
     ];
-    languageModelRequirements = [
+    languageModelRequirements: LanguageModelRequirement[] = [
         {
-            agent: this.id,
-            purpose: 'suggest-terminal-commands',
+            purpose: 'suggest-terminal-commands'
         }
     ];
 
@@ -111,13 +110,14 @@ recent-terminal-contents:
         shell: string,
         recentTerminalContents: string[],
     }): Promise<string[]> {
-
-        const lms = await this.languageModelRegistry.selectLanguageModels(this.languageModelRequirements[0]);
-        if (lms.length === 0) {
+        const lm = await this.languageModelRegistry.selectLanguageModel({
+            agent: this.id,
+            ...this.languageModelRequirements[0]
+        });
+        if (!lm) {
             this.logger.error('No language model available for the AI Terminal Agent.');
             return [];
         }
-        const lm = lms[0];
 
         const systemPrompt = await this.promptService.getPrompt('ai-terminal:system-prompt', input);
         const userPrompt = await this.promptService.getPrompt('ai-terminal:user-prompt', input);

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -14,7 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Agent, isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelRegistry, LanguageModelRequirement, LanguageModelResponse, PromptService } from '@theia/ai-core/lib/common';
+import {
+    Agent, isLanguageModelStreamResponse, isLanguageModelTextResponse,
+    LanguageModelRegistry, LanguageModelRequirement, LanguageModelResponse, PromptService
+} from '@theia/ai-core/lib/common';
 import { ILogger } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Agents select LLM based on settings and requirements or default
- Ensure we show the default case in case requirements do not set LLM

Fixes https://github.com/eclipsesource/osweek-2024/issues/100

#### How to test

- Check that the AI Terminal Assistant has a LLM set in the configuration even though there is none in the requirements or settings.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
