### PR TITLE
Introduce optional display text to `ChatRequest`

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -219,7 +219,8 @@ export class ChatViewTreeWidget extends TreeWidget {
     }
 
     private renderChatRequest(node: RequestNode): React.ReactNode {
-        const markdownString = new MarkdownStringImpl(node.request.request.text, { supportHtml: true, isTrusted: true });
+        const text = node.request.request.displayText ?? node.request.request.text;
+        const markdownString = new MarkdownStringImpl(text, { supportHtml: true, isTrusted: true });
         return (
             <div className={'theia-RequestNode'}>
                 {<MarkdownWrapper

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -62,6 +62,7 @@ export interface ChatModel {
 
 export interface ChatRequest {
     readonly text: string;
+    readonly displayText?: string;
 }
 
 export interface ChatRequestModel {


### PR DESCRIPTION
Introduces an optional `displayText` property to `ChatRequest` to allow adding more context to initiate a chat conversation for the LLM that we don't want to show to the user in the UI.

Fixes https://github.com/eclipsesource/osweek-2024/issues/109