### PR TITLE
Activate/Deactivate Agents

### DIFF
--- a/packages/ai-chat/src/common/chat-agent-service.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.ts
@@ -23,7 +23,7 @@ import { ContributionProvider, ILogger } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { ChatAgent } from './chat-agents';
 import { ChatRequestModel, ChatRequestModelImpl } from './chat-model';
-import { DisabledAgentsService } from '@theia/ai-core';
+import { AgentService } from '@theia/ai-core';
 
 export const ChatAgentService = Symbol('ChatAgentService');
 /**
@@ -44,8 +44,8 @@ export class ChatAgentServiceImpl implements ChatAgentService {
     @inject(ILogger)
     protected logger: ILogger;
 
-    @inject(DisabledAgentsService)
-    protected disabledAgentsService: DisabledAgentsService;
+    @inject(AgentService)
+    protected agentService: AgentService;
 
     getAgent(id: string, includeDisabledAgent = false): ChatAgent | undefined {
         if (!includeDisabledAgent && !this._agentIsEnabled(id)) {
@@ -62,7 +62,7 @@ export class ChatAgentServiceImpl implements ChatAgentService {
     }
 
     private _agentIsEnabled(id: string): boolean {
-        return this.disabledAgentsService.isEnabled(id);
+        return this.agentService.isEnabled(id);
     }
     invokeAgent(agentId: string, request: ChatRequestModelImpl): Promise<void> {
         const agent = this.getAgent(agentId);

--- a/packages/ai-chat/src/common/chat-agent-service.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.ts
@@ -23,15 +23,16 @@ import { ContributionProvider, ILogger } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { ChatAgent } from './chat-agents';
 import { ChatRequestModel, ChatRequestModelImpl } from './chat-model';
+import { DisabledAgentsService } from '@theia/ai-core';
 
 export const ChatAgentService = Symbol('ChatAgentService');
 /**
  * The ChatAgentService provides access to the available chat agents.
  */
 export interface ChatAgentService {
-    getAgents(): ChatAgent[];
-    getAgent(id: string): ChatAgent | undefined;
-    getAgentsByName(name: string): ChatAgent[];
+    getAgents(includeDisabledAgent?: boolean): ChatAgent[];
+    getAgent(id: string, includeDisabledAgent?: boolean): ChatAgent | undefined;
+    getAgentsByName(name: string, includeDisabledAgent?: boolean): ChatAgent[];
     invokeAgent(agentId: string, request: ChatRequestModel): Promise<void>;
 }
 @injectable()
@@ -43,14 +44,25 @@ export class ChatAgentServiceImpl implements ChatAgentService {
     @inject(ILogger)
     protected logger: ILogger;
 
-    getAgent(id: string): ChatAgent | undefined {
-        return this.agents.getContributions().find(agent => agent.id === id);
+    @inject(DisabledAgentsService)
+    protected disabledAgentsService: DisabledAgentsService;
+
+    getAgent(id: string, includeDisabledAgent = false): ChatAgent | undefined {
+        if (!includeDisabledAgent && !this._agentIsEnabled(id)) {
+            return;
+        }
+        return this.getAgents(includeDisabledAgent).find(agent => agent.id === id);
     }
-    getAgents(): ChatAgent[] {
-        return this.agents.getContributions();
+    getAgents(includeDisabledAgent = false): ChatAgent[] {
+        return this.agents.getContributions()
+            .filter(a => includeDisabledAgent || this._agentIsEnabled(a.id));
     }
-    getAgentsByName(name: string): ChatAgent[] {
-        return this.getAgents().filter(a => a.name === name);
+    getAgentsByName(name: string, includeDisabledAgent = false): ChatAgent[] {
+        return this.getAgents(includeDisabledAgent).filter(a => a.name === name);
+    }
+
+    private _agentIsEnabled(id: string): boolean {
+        return this.disabledAgentsService.isEnabled(id);
     }
     invokeAgent(agentId: string, request: ChatRequestModelImpl): Promise<void> {
         const agent = this.getAgent(agentId);

--- a/packages/ai-code-fix/src/browser/code-fix-agent.ts
+++ b/packages/ai-code-fix/src/browser/code-fix-agent.ts
@@ -34,7 +34,7 @@ export interface CodeFixAgent extends Agent {
 
 @injectable()
 export class CodeFixAgentImpl implements CodeFixAgent {
-    variables: string[];
+    variables: string[] = [];
 
     @inject(LanguageModelRegistry)
     protected languageModelRegistry: LanguageModelRegistry;

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -23,7 +23,7 @@ import { LanguageModelRenderer } from './language-model-renderer';
 import { TemplateRenderer } from './template-settings-renderer';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { AIVariableConfigurationWidget } from './variable-configuration-widget';
-import { AgentService, DisabledAgentsService } from '../../common/agent-service';
+import { AgentService } from '../../common/agent-service';
 
 @injectable()
 export class AIAgentConfigurationWidget extends ReactWidget {
@@ -45,9 +45,6 @@ export class AIAgentConfigurationWidget extends ReactWidget {
 
     @inject(AIConfigurationSelectionService)
     protected readonly aiConfigurationSelectionService: AIConfigurationSelectionService;
-
-    @inject(DisabledAgentsService)
-    protected disabledAgentsService: DisabledAgentsService;
 
     protected languageModels: LanguageModel[] | undefined;
 
@@ -92,7 +89,7 @@ export class AIAgentConfigurationWidget extends ReactWidget {
             return <div>Please select an Agent first!</div>;
         }
 
-        const enabled = this.disabledAgentsService.isEnabled(agent.id);
+        const enabled = this.agentService.isEnabled(agent.id);
 
         return <div key={agent.id} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
             <div className='settings-section-title settings-section-category-title' style={{ paddingLeft: 0, paddingBottom: 10 }}>{agent.name}</div>
@@ -145,11 +142,11 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         if (!agent) {
             return false;
         }
-        const enabled = this.disabledAgentsService.isEnabled(agent.id);
+        const enabled = this.agentService.isEnabled(agent.id);
         if (enabled) {
-            this.disabledAgentsService.disableAgent(agent.id);
+            this.agentService.disableAgent(agent.id);
         } else {
-            this.disabledAgentsService.enableAgent(agent.id);
+            this.agentService.enableAgent(agent.id);
         }
         this.update();
     };

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -14,9 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ContributionProvider } from '@theia/core';
 import { codicon, ReactWidget } from '@theia/core/lib/browser';
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { Agent, LanguageModel, LanguageModelRegistry, PromptCustomizationService } from '../../common';
 import { AISettingsService } from '../ai-settings-service';
@@ -24,6 +23,7 @@ import { LanguageModelRenderer } from './language-model-renderer';
 import { TemplateRenderer } from './template-settings-renderer';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { AIVariableConfigurationWidget } from './variable-configuration-widget';
+import { AgentService, DisabledAgentsService } from '../../common/agent-service';
 
 @injectable()
 export class AIAgentConfigurationWidget extends ReactWidget {
@@ -31,8 +31,8 @@ export class AIAgentConfigurationWidget extends ReactWidget {
     static readonly ID = 'ai-agent-configuration-container-widget';
     static readonly LABEL = 'Agents';
 
-    @inject(ContributionProvider) @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
@@ -45,6 +45,9 @@ export class AIAgentConfigurationWidget extends ReactWidget {
 
     @inject(AIConfigurationSelectionService)
     protected readonly aiConfigurationSelectionService: AIConfigurationSelectionService;
+
+    @inject(DisabledAgentsService)
+    protected disabledAgentsService: DisabledAgentsService;
 
     protected languageModels: LanguageModel[] | undefined;
 
@@ -72,7 +75,7 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         return <div className='ai-agent-configuration-main'>
             <div className='configuration-agents-list preferences-tree-widget theia-TreeContainer' style={{ width: '25%' }}>
                 <ul>
-                    {this.agents.getContributions().map(agent =>
+                    {this.agentService.getAgents(true).map(agent =>
                         <li key={agent.id} className='theia-TreeNode theia-CompositeTreeNode theia-ExpandableTreeNode' onClick={() => this.setActiveAgent(agent)}>{agent.name}</li>
                     )}
                 </ul>
@@ -88,9 +91,18 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         if (!agent) {
             return <div>Please select an Agent first!</div>;
         }
+
+        const enabled = this.disabledAgentsService.isEnabled(agent.id);
+
         return <div key={agent.id} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
             <div className='settings-section-title settings-section-category-title' style={{ paddingLeft: 0, paddingBottom: 10 }}>{agent.name}</div>
             <div style={{ paddingBottom: 10 }}>{agent.description}</div>
+            <div style={{ paddingBottom: 10 }}>
+                <label>
+                    <input type="checkbox" checked={enabled} onChange={this.toggleAgentEnabled} />
+                    Enable Agent
+                </label>
+            </div>
             <div style={{ paddingBottom: 10 }}>
                 <span style={{ marginRight: '0.5rem' }}>Variables:</span>
                 <ul className='variable-references'>
@@ -127,5 +139,19 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         this.aiConfigurationSelectionService.setActiveAgent(agent);
         this.update();
     }
+
+    private toggleAgentEnabled = () => {
+        const agent = this.aiConfigurationSelectionService.getActiveAgent();
+        if (!agent) {
+            return false;
+        }
+        const enabled = this.disabledAgentsService.isEnabled(agent.id);
+        if (enabled) {
+            this.disabledAgentsService.disableAgent(agent.id);
+        } else {
+            this.disabledAgentsService.enableAgent(agent.id);
+        }
+        this.update();
+    };
 
 }

--- a/packages/ai-core/src/browser/ai-configuration/variable-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/variable-configuration-widget.tsx
@@ -14,13 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ContributionProvider } from '@theia/core';
 import { codicon, ReactWidget } from '@theia/core/lib/browser';
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { Agent, AIVariable, AIVariableService } from '../../common';
 import { AIAgentConfigurationWidget } from './agent-configuration-widget';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
+import { AgentService } from '../../common/agent-service';
 
 @injectable()
 export class AIVariableConfigurationWidget extends ReactWidget {
@@ -31,8 +31,8 @@ export class AIVariableConfigurationWidget extends ReactWidget {
     @inject(AIVariableService)
     protected readonly variableService: AIVariableService;
 
-    @inject(ContributionProvider) @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
 
     @inject(AIConfigurationSelectionService)
     protected readonly aiConfigurationSelectionService: AIConfigurationSelectionService;
@@ -104,7 +104,7 @@ export class AIVariableConfigurationWidget extends ReactWidget {
     }
 
     protected getAgentsForVariable(variable: AIVariable): Agent[] {
-        return this.agents.getContributions().filter(a => a.variables?.includes(variable.id));
+        return this.agentService.getAgents().filter(a => a.variables?.includes(variable.id));
     }
 }
 

--- a/packages/ai-core/src/browser/ai-core-frontend-application-contribution.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-application-contribution.ts
@@ -15,20 +15,20 @@
 // *****************************************************************************
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable, named } from '@theia/core/shared/inversify';
-import { ContributionProvider } from '@theia/core';
-import { Agent, PromptService } from '../common';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '../common';
+import { AgentService } from '../common/agent-service';
 
 @injectable()
 export class AICoreFrontendApplicationContribution implements FrontendApplicationContribution {
-    @inject(ContributionProvider) @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    private readonly agentService: AgentService;
 
     @inject(PromptService)
     private readonly promptService: PromptService;
 
     onStart(): void {
-        this.agents.getContributions().forEach(a => {
+        this.agentService.getAgents(true).forEach(a => {
             a.promptTemplates.forEach(t => {
                 this.promptService.storePrompt(t.id, t.template);
             });

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -60,7 +60,7 @@ import { AIConfigurationSelectionService } from './ai-configuration/ai-configura
 import { TheiaVariableContribution } from './theia-variable-contribution';
 import { TodayVariableContribution } from '../common/today-variable-contribution';
 import { AgentsVariableContribution } from '../common/agents-variable-contribution';
-import { AgentService, AgentServiceImpl, DisabledAgentsService, DisabledAgentsServiceImpl } from '../common/agent-service';
+import { AgentService, AgentServiceImpl } from '../common/agent-service';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -140,9 +140,6 @@ export default new ContainerModule(bind => {
 
     bind(FunctionCallRegistry).to(FunctionCallRegistryImpl).inSingletonScope();
     bindContributionProvider(bind, ToolProvider);
-
-    bind(DisabledAgentsServiceImpl).toSelf().inSingletonScope();
-    bind(DisabledAgentsService).toService(DisabledAgentsServiceImpl);
 
     bind(AgentServiceImpl).toSelf().inSingletonScope();
     bind(AgentService).toService(AgentServiceImpl);

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -60,6 +60,7 @@ import { AIConfigurationSelectionService } from './ai-configuration/ai-configura
 import { TheiaVariableContribution } from './theia-variable-contribution';
 import { TodayVariableContribution } from '../common/today-variable-contribution';
 import { AgentsVariableContribution } from '../common/agents-variable-contribution';
+import { AgentService, AgentServiceImpl, DisabledAgentsService, DisabledAgentsServiceImpl } from '../common/agent-service';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -139,4 +140,10 @@ export default new ContainerModule(bind => {
 
     bind(FunctionCallRegistry).to(FunctionCallRegistryImpl).inSingletonScope();
     bindContributionProvider(bind, ToolProvider);
+
+    bind(DisabledAgentsServiceImpl).toSelf().inSingletonScope();
+    bind(DisabledAgentsService).toService(DisabledAgentsServiceImpl);
+
+    bind(AgentServiceImpl).toSelf().inSingletonScope();
+    bind(AgentService).toService(AgentServiceImpl);
 });

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -14,14 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
-import { Agent, PromptCustomizationService, PromptTemplate } from '../common';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { PromptCustomizationService, PromptTemplate } from '../common';
 import { PromptPreferences } from './prompt-preferences';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { ContributionProvider, DisposableCollection, URI } from '@theia/core';
+import { DisposableCollection, URI } from '@theia/core';
 import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { OpenerService } from '@theia/core/lib/browser';
+import { AgentService } from '../common/agent-service';
 
 @injectable()
 export class FrontendPromptCustomizationServiceImpl implements PromptCustomizationService {
@@ -35,8 +36,8 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
 
-    @inject(ContributionProvider) @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
 
     protected readonly trackedTemplateURIs = new Set<string>();
     protected readonly templates = new Map<string, string>();
@@ -156,7 +157,7 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
     }
 
     getTemplate(id: string): PromptTemplate | undefined {
-        for (const agent of this.agents.getContributions()) {
+        for (const agent of this.agentService.getAgents(true)) {
             for (const template of agent.promptTemplates) {
                 if (template.id === id) {
                     return template;

--- a/packages/ai-core/src/common/agent-service.ts
+++ b/packages/ai-core/src/common/agent-service.ts
@@ -31,15 +31,6 @@ export interface AgentService {
      * @returns An array of Agent objects.
      */
     getAgents(includeDisabledAgents?: boolean): Agent[];
-}
-
-export const DisabledAgentsService = Symbol('DisabledAgentsService');
-/**
- * Service to enable or disable agents, and to obtain their current
- * status.
- */
-export interface DisabledAgentsService {
-
     /**
      * Enable the agent with the specified id.
      * @param agentId the agent id.
@@ -64,8 +55,7 @@ export class AgentServiceImpl implements AgentService {
     @inject(ContributionProvider) @named(Agent)
     protected readonly agentsProvider: ContributionProvider<Agent>;
 
-    @inject(DisabledAgentsService)
-    protected disabledAgentsService: DisabledAgentsService;
+    protected disabledAgents = new Set<string>();
 
     private get agents(): Agent[] {
         return this.agentsProvider.getContributions();
@@ -75,15 +65,9 @@ export class AgentServiceImpl implements AgentService {
         if (includeDisabledAgents) {
             return this.agents;
         } else {
-            return this.agents.filter(agent => this.disabledAgentsService.isEnabled(agent.id));
+            return this.agents.filter(agent => this.isEnabled(agent.id));
         }
     }
-}
-
-@injectable()
-export class DisabledAgentsServiceImpl implements DisabledAgentsService {
-
-    protected disabledAgents = new Set<string>();
 
     enableAgent(agentId: string): void {
         this.disabledAgents.delete(agentId);

--- a/packages/ai-core/src/common/agent-service.ts
+++ b/packages/ai-core/src/common/agent-service.ts
@@ -1,0 +1,99 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { ContributionProvider } from '@theia/core';
+import { Agent } from './agent';
+
+export const AgentService = Symbol('AgentService');
+
+/**
+ * Service to access the list of known Agents.
+ */
+export interface AgentService {
+    /**
+     * Retrieves a list of agents.
+     * @param includeDisabledAgents - Optional. Specifies whether to include disabled agents in the result.
+     * This should usually remain false (or undefined), except when listing agents in a settings/configuration context.
+     * default: false
+     * @returns An array of Agent objects.
+     */
+    getAgents(includeDisabledAgents?: boolean): Agent[];
+}
+
+export const DisabledAgentsService = Symbol('DisabledAgentsService');
+/**
+ * Service to enable or disable agents, and to obtain their current
+ * status.
+ */
+export interface DisabledAgentsService {
+
+    /**
+     * Enable the agent with the specified id.
+     * @param agentId the agent id.
+     */
+    enableAgent(agentId: string): void;
+    /**
+     * disable the agent with the specified id.
+     * @param agentId the agent id.
+     */
+    disableAgent(agentId: string): void;
+    /**
+     * query whether this agent is currently enabled or disabled.
+     * @param agentId the agent id.
+     * @return true if the agent is enabled, false otherwise.
+     */
+    isEnabled(agentId: string): boolean;
+}
+
+@injectable()
+export class AgentServiceImpl implements AgentService {
+
+    @inject(ContributionProvider) @named(Agent)
+    protected readonly agentsProvider: ContributionProvider<Agent>;
+
+    @inject(DisabledAgentsService)
+    protected disabledAgentsService: DisabledAgentsService;
+
+    private get agents(): Agent[] {
+        return this.agentsProvider.getContributions();
+    }
+
+    getAgents(includeDisabledAgents = false): Agent[] {
+        if (includeDisabledAgents) {
+            return this.agents;
+        } else {
+            return this.agents.filter(agent => this.disabledAgentsService.isEnabled(agent.id));
+        }
+    }
+}
+
+@injectable()
+export class DisabledAgentsServiceImpl implements DisabledAgentsService {
+
+    protected disabledAgents = new Set<string>();
+
+    enableAgent(agentId: string): void {
+        this.disabledAgents.delete(agentId);
+    }
+
+    disableAgent(agentId: string): void {
+        this.disabledAgents.add(agentId);
+    }
+
+    isEnabled(agentId: string): boolean {
+        return !this.disabledAgents.has(agentId);
+    }
+}

--- a/packages/ai-core/src/common/agents-variable-contribution.ts
+++ b/packages/ai-core/src/common/agents-variable-contribution.ts
@@ -13,10 +13,10 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable } from './variable-service';
-import { ContributionProvider, MaybePromise } from '@theia/core';
-import { Agent } from './agent';
+import { MaybePromise } from '@theia/core';
+import { AgentService } from './agent-service';
 
 export const AGENTS_VARIABLE: AIVariable = {
     id: 'agents',
@@ -37,9 +37,8 @@ export interface AgentDescriptor {
 @injectable()
 export class AgentsVariableContribution implements AIVariableContribution, AIVariableResolver {
 
-    @inject(ContributionProvider)
-    @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
 
     registerVariables(service: AIVariableService): void {
         service.registerResolver(AGENTS_VARIABLE, this);
@@ -59,7 +58,7 @@ export class AgentsVariableContribution implements AIVariableContribution, AIVar
     }
 
     resolveAgentsVariable(_request: AIVariableResolutionRequest): ResolvedAgentsVariable {
-        const agents = this.agents.getContributions().map(agent => ({
+        const agents = this.agentService.getAgents().map(agent => ({
             id: agent.id,
             name: agent.name,
             description: agent.description

--- a/packages/ai-core/src/common/index.ts
+++ b/packages/ai-core/src/common/index.ts
@@ -22,3 +22,4 @@ export * from './prompt-service';
 export * from './variable-service';
 export * from './function-call-registry';
 export * from './protocol';
+export * from './agent-service';

--- a/packages/ai-history/src/browser/ai-history-widget.tsx
+++ b/packages/ai-history/src/browser/ai-history-widget.tsx
@@ -13,10 +13,9 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { Agent, CommunicationRecordingService, CommunicationRequestEntry, CommunicationResponseEntry } from '@theia/ai-core';
-import { ContributionProvider } from '@theia/core';
+import { Agent, AgentService, CommunicationRecordingService, CommunicationRequestEntry, CommunicationResponseEntry } from '@theia/ai-core';
 import { codicon, ReactWidget } from '@theia/core/lib/browser';
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { CommunicationCard } from './ai-history-communication-card';
 import { SelectComponent } from '@theia/core/lib/browser/widgets/select-component';
@@ -25,8 +24,8 @@ import { SelectComponent } from '@theia/core/lib/browser/widgets/select-componen
 export class AIHistoryView extends ReactWidget {
     @inject(CommunicationRecordingService)
     protected recordingService: CommunicationRecordingService;
-    @inject(ContributionProvider) @named(Agent)
-    protected readonly agents: ContributionProvider<Agent>;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
 
     public static ID = 'ai-history-widget';
     static LABEL = 'AI Agent History';
@@ -47,7 +46,7 @@ export class AIHistoryView extends ReactWidget {
         this.update();
         this.toDispose.push(this.recordingService.onDidRecordRequest(entry => this.historyContentUpdated(entry)));
         this.toDispose.push(this.recordingService.onDidRecordResponse(entry => this.historyContentUpdated(entry)));
-        this.selectAgent(this.agents.getContributions()[0]);
+        this.selectAgent(this.agentService.getAgents(true)[0]);
     }
 
     protected selectAgent(agent: Agent | undefined): void {
@@ -65,8 +64,8 @@ export class AIHistoryView extends ReactWidget {
         return (
             <div className='agent-history-widget'>
                 <SelectComponent
-                    options={this.agents.getContributions().map(agent => ({ value: agent.id, label: agent.name, description: agent.description }))}
-                    onChange={value => this.selectAgent(this.agents.getContributions().find(agent => agent.id === value.value))}
+                    options={this.agentService.getAgents(true).map(agent => ({ value: agent.id, label: agent.name, description: agent.description }))}
+                    onChange={value => this.agentService.getAgents(true).find(agent => agent.id === value.value)}
                     defaultValue={this.selectedAgent?.id} />
                 <div className='agent-history'>
                     {this.renderHistory()}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- add an AgentService to list all (enabled) agents
- add a DisabledAgentsService to track enabled/disabled agents
- update the configuration UI to enable/disable agents
- by default, all agents are enabled

#### How to test

- open the AI Configuration panel
- select an Agent
- uncheck "enable"
- verify that the Agent is properly disabled, for example:
  - try to talk to the disabled agent with `@Agent your question`
    - the question should be answered by the default agent (assuming you didn't disable it)
  - ask an agent about available agents, using the `#agents` variables: `which agents are available? #agents`
    - the disable agent(s) shouldn't appear
- you can re-enable the agent and test these steps again
- disabled agents may still appear in the UI (e.g. AI Configuration, Agent History), but they shouldn't be involved in Chat communications (`@Agent`, `#agents`)

![image](https://github.com/user-attachments/assets/2c41b68c-282b-44ff-b0f3-20bbde2eedcc)

#### Follow-ups

Settings should be persisted: https://github.com/eclipsesource/osweek-2024/issues/112
Custom UIs should be disabled: https://github.com/eclipsesource/osweek-2024/issues/113