### PR TITLE
Add function parsing to chat request parser and abstract chat agent

### DIFF
--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -20,12 +20,13 @@ import { ChatRequestParserImpl } from './chat-request-parser';
 import { ChatAgentLocation } from './chat-agents';
 import { ChatRequest } from './chat-model';
 import { expect } from 'chai';
-import { DefaultAIVariableService } from '@theia/ai-core';
+import { DefaultAIVariableService, FunctionCallRegistry, FunctionCallRegistryImpl } from '@theia/ai-core';
 
 describe('ChatRequestParserImpl', () => {
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
     const variableService = sinon.createStubInstance(DefaultAIVariableService);
-    const parser = new ChatRequestParserImpl(chatAgentService, variableService);
+    const functionCallRegistry: FunctionCallRegistry = sinon.createStubInstance(FunctionCallRegistryImpl);
+    const parser = new ChatRequestParserImpl(chatAgentService, variableService, functionCallRegistry);
 
     it('parses simple text', () => {
         const req: ChatRequest = {

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -38,7 +38,7 @@ import {
 import { AIVariable, AIVariableService, FunctionCallRegistry, ToolRequest } from '@theia/ai-core';
 
 const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
-const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // An #! tool function
+const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // A ~ tool function
 const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-variable with an optional : arg (#file:workspace/path/name.ext)
 // const slashReg = /\/([\w_\-]+)(?=(\s|$|\b))/i; // A / command
 
@@ -203,9 +203,9 @@ export class ChatRequestParserImpl {
             return;
         }
 
-        const [full, name] = nextFunctionMatch;
+        const [full, id] = nextFunctionMatch;
 
-        const maybeToolRequest = this.functionCallRegistry.getFunction(name);
+        const maybeToolRequest = this.functionCallRegistry.getFunction(id);
         if (!maybeToolRequest) {
             return;
         }

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -25,7 +25,9 @@ import { ChatAgentLocation } from './chat-agents';
 import { ChatRequest } from './chat-model';
 import {
     chatAgentLeader,
+    chatFunctionLeader,
     ChatRequestAgentPart,
+    ChatRequestFunctionPart,
     ChatRequestTextPart,
     ChatRequestVariablePart,
     chatVariableLeader,
@@ -33,9 +35,10 @@ import {
     ParsedChatRequest,
     ParsedChatRequestPart,
 } from './chat-parsed-request';
-import { AIVariable, AIVariableService } from '@theia/ai-core';
+import { AIVariable, AIVariableService, FunctionCallRegistry, ToolRequest } from '@theia/ai-core';
 
 const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
+const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // An #! tool function
 const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-variable with an optional : arg (#file:workspace/path/name.ext)
 // const slashReg = /\/([\w_\-]+)(?=(\s|$|\b))/i; // A / command
 
@@ -48,19 +51,31 @@ export interface ChatRequestParser {
 export class ChatRequestParserImpl {
     constructor(
         @inject(ChatAgentService) private readonly agentService: ChatAgentService,
-        @inject(AIVariableService) private readonly variableService: AIVariableService
+        @inject(AIVariableService) private readonly variableService: AIVariableService,
+        @inject(FunctionCallRegistry) private readonly functionCallRegistry: FunctionCallRegistry
     ) { }
 
     parseChatRequest(request: ChatRequest, location: ChatAgentLocation): ParsedChatRequest {
         const parts: ParsedChatRequestPart[] = [];
         const variables = new Map<string, AIVariable>();
+        const toolRequests = new Map<string, ToolRequest<object>>();
         const message = request.text;
         for (let i = 0; i < message.length; i++) {
             const previousChar = message.charAt(i - 1);
             const char = message.charAt(i);
             let newPart: ParsedChatRequestPart | undefined;
+
             if (previousChar.match(/\s/) || i === 0) {
-                if (char === chatVariableLeader) {
+                if (char === chatFunctionLeader) {
+                    const functionPart = this.tryParseFunction(
+                        message.slice(i),
+                        i
+                    );
+                    newPart = functionPart;
+                    if (functionPart) {
+                        toolRequests.set(functionPart.toolRequest.id, functionPart.toolRequest);
+                    }
+                } else if (char === chatVariableLeader) {
                     const variablePart = this.tryToParseVariable(
                         message.slice(i),
                         i,
@@ -112,7 +127,7 @@ export class ChatRequestParserImpl {
             );
         }
 
-        return { request, parts, variables };
+        return { request, parts, toolRequests, variables };
     }
 
     private tryToParseAgent(
@@ -180,5 +195,22 @@ export class ChatRequestParserImpl {
         const varRange = new OffsetRangeImpl(offset, offset + full.length);
 
         return new ChatRequestVariablePart(varRange, name, variableArg);
+    }
+
+    private tryParseFunction(message: string, offset: number): ChatRequestFunctionPart | undefined {
+        const nextFunctionMatch = message.match(functionReg);
+        if (!nextFunctionMatch) {
+            return;
+        }
+
+        const [full, name] = nextFunctionMatch;
+
+        const maybeToolRequest = this.functionCallRegistry.getFunction(name);
+        if (!maybeToolRequest) {
+            return;
+        }
+
+        const functionRange = new OffsetRangeImpl(offset, offset + full.length);
+        return new ChatRequestFunctionPart(functionRange, maybeToolRequest);
     }
 }

--- a/packages/ai-core/src/common/function-call-registry.ts
+++ b/packages/ai-core/src/common/function-call-registry.ts
@@ -26,6 +26,8 @@ export const FunctionCallRegistry = Symbol('FunctionCallRegistry');
 export interface FunctionCallRegistry {
     registerFunction(tool: ToolRequest<object>): void;
 
+    getFunction(toolId: string): ToolRequest<object> | undefined;
+
     getFunctions(...toolIds: string[]): ToolRequest<object>[];
 }
 
@@ -56,6 +58,10 @@ export class FunctionCallRegistryImpl implements FunctionCallRegistry {
         } else {
             this.functions.set(tool.id, tool);
         }
+    }
+
+    getFunction(toolId: string): ToolRequest<object> | undefined {
+        return this.functions.get(toolId);
     }
 
     getFunctions(...toolIds: string[]): ToolRequest<object>[] {

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -35,7 +35,7 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
 export interface ToolRequest<T extends object> {
     id: string;
     name: string;
-    parameters?: { [key: string]: unknown };
+    parameters?: { type?: 'object', properties: Record<string, { type: string, [key: string]: unknown }> };
     description?: string;
     handler: (arg_string: string) => Promise<unknown>;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Implements https://github.com/eclipsesource/osweek-2024/issues/101

- Parse function/tools lead by a `~`. E.g. `~getWorkspaceFileList`
- Put parsed tool requests in the ParsedChatRequest to facilitate reading them in agents.
- Exten abstract chat agent to hand over parsed tools to the language model.
- Improve tool request parameters type
- Add autocompletion for tools/functions to the chat input

#### How to test

- Open a chat
- Type `~` to see tool completion. select one
- prompt related to the tool (e.g. describe workspace content)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
