### PR TITLE
Improve tool call formatting

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -31,13 +31,12 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallRe
     }
     render(response: ToolCallResponseContent): ReactNode {
         return <h4 className='theia-toolCall'>
-            {response.finished ? <Checkmark /> : <Spinner />}
-            <span>Executing tool call [{response.asString()}]</span>
-            {response.finished &&
+            {response.finished ?
                 <details>
-                    <summary>Tool Response</summary>
+                    <summary>Ran {response.name}</summary>
                     <p>{response.result}</p>
                 </details>
+                : <span><Spinner /> Running [{response.name}]</span>
             }
         </h4>;
 
@@ -47,7 +46,4 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallRe
 
 const Spinner = () => (
     <i className="fa fa-spinner fa-spin"></i>
-);
-const Checkmark = () => (
-    <i className="fa fa-check"></i>
 );

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -181,6 +181,19 @@ div:last-child>.theia-ChatNode {
     background-color: #ccc;
 }
 
+.theia-toolCall {
+    font-weight: normal;
+    color: var(--theia-descriptionForeground);
+    line-height: 20px;
+    margin-bottom: 6px;
+    cursor: pointer;
+}
+
+.theia-toolCall .fa,
+.theia-toolCall details summary::marker {
+    color: var(--theia-button-background);
+}
+
 .spinner {
     display: inline-block;
     animation: spin 2s linear infinite;

--- a/packages/ai-history/src/browser/ai-history-contribution.ts
+++ b/packages/ai-history/src/browser/ai-history-contribution.ts
@@ -31,7 +31,6 @@ export class AIHistoryViewContribution extends AbstractViewContribution<AIHistor
                 rank: 100
             },
             toggleCommandId: AI_HISTORY_TOGGLE_COMMAND_ID,
-            toggleKeybinding: 'ctrlcmd+shift+r'
         });
     }
 


### PR DESCRIPTION
Applies minor CSS improvements and shows tool calls in a less verbose manner.

![image](https://github.com/user-attachments/assets/d7b6fe95-7572-4bd7-8a61-39a4e13633da)

Also removes short cut from AI history view: It isn't so important to assign a short cut by default imho, and it captures the typical browser reload shortcut.