### PR TITLE
Improve styling of input

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -111,7 +111,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
             fontSize: 13,
             cursorWidth: 1,
             maxHeight: -1,
-            scrollbar: { vertical: 'hidden', horizontal: 'hidden' },
+            scrollbar: { horizontal: 'hidden' },
             automaticLayout: true,
             lineNumbers: 'off',
             lineHeight: 20,
@@ -131,6 +131,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         editor.getControl().onDidChangeModelContent(() => {
             layout();
         });
+
         editorRef.current = editor;
     };
 
@@ -171,9 +172,6 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         } else {
             placeholderRef.current?.classList.remove(hiddenClass);
         }
-
-        const contentHeight = editor.getControl().getContentHeight();
-        editorContainerRef.current!.style.height = `${contentHeight + 8}px`;
     }
 
     const onKeyDown = React.useCallback((event: React.KeyboardEvent) => {

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -87,7 +87,9 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
 
     const [inProgress, setInProgress] = React.useState(false);
     // eslint-disable-next-line no-null/no-null
-    const ref = React.useRef<HTMLDivElement | null>(null);
+    const editorContainerRef = React.useRef<HTMLDivElement | null>(null);
+    // eslint-disable-next-line no-null/no-null
+    const placeholderRef = React.useRef<HTMLDivElement | null>(null);
     const editorRef = React.useRef<MonacoEditor | undefined>(undefined);
     const allRequests = props.chatModel.getRequests();
     const lastRequest = allRequests.length === 0 ? undefined : allRequests[allRequests.length - 1];
@@ -95,7 +97,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
 
     const createInputElement = async () => {
         const resource = await props.untitledResourceResolver.createUntitledResource('', CHAT_VIEW_LANGUAGE_EXTENSION);
-        const editor = await props.editorProvider.createInline(resource.uri, ref.current!, {
+        const editor = await props.editorProvider.createInline(resource.uri, editorContainerRef.current!, {
             language: CHAT_VIEW_LANGUAGE_EXTENSION,
             // Disable code lens, inlay hints and hover support to avoid console errors from other contributions
             codeLens: false,
@@ -105,15 +107,29 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
             scrollBeyondLastLine: false,
             scrollBeyondLastColumn: 0,
             minHeight: 1,
-            renderFinalNewline: 'on',
             fontFamily: 'var(--theia-ui-font-family)',
             fontSize: 13,
+            cursorWidth: 1,
             maxHeight: -1,
             scrollbar: { vertical: 'hidden', horizontal: 'hidden' },
             automaticLayout: true,
             lineNumbers: 'off',
-            lineHeight: 15,
-            padding: { top: 10, bottom: 5 },
+            lineHeight: 20,
+            padding: { top: 8 },
+            suggest: {
+                showIcons: true,
+                showSnippets: false,
+                showWords: false,
+                showStatusBar: false,
+                insertMode: 'replace',
+            },
+            bracketPairColorization: { enabled: false },
+            wrappingStrategy: 'advanced',
+            stickyScroll: { enabled: false },
+        });
+
+        editor.getControl().onDidChangeModelContent(() => {
+            layout();
         });
         editorRef.current = editor;
     };
@@ -144,6 +160,22 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         }
     };
 
+    function layout(): void {
+        if (editorRef.current === undefined) {
+            return;
+        }
+        const hiddenClass = 'hidden';
+        const editor = editorRef.current;
+        if (editor.document.textEditorModel.getValue().length > 0) {
+            placeholderRef.current?.classList.add(hiddenClass);
+        } else {
+            placeholderRef.current?.classList.remove(hiddenClass);
+        }
+
+        const contentHeight = editor.getControl().getContentHeight();
+        editorContainerRef.current!.style.height = `${contentHeight + 8}px`;
+    }
+
     const onKeyDown = React.useCallback((event: React.KeyboardEvent) => {
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
@@ -152,7 +184,11 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     }, []);
 
     return <div className='theia-ChatInput'>
-        <div className='theia-ChatInput-Editor' ref={ref} onKeyDown={onKeyDown}></div>
+        <div className='theia-ChatInput-Editor-Box'>
+            <div className='theia-ChatInput-Editor' ref={editorContainerRef} onKeyDown={onKeyDown}>
+                <div ref={placeholderRef} className='theia-ChatInput-Editor-Placeholder'>Enter your question</div>
+            </div>
+        </div>
         <div className="theia-ChatInputOptions">
             {
                 inProgress ? <span

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -21,6 +21,7 @@
   user-select: text;
   -webkit-user-select: text;
   border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
+  overflow-wrap: break-word
 }
 
 div:last-child > .theia-ChatNode {
@@ -140,7 +141,6 @@ div:last-child > .theia-ChatNode {
 }
 
 .theia-ChatInput-Editor .monaco-editor {
-  flex-grow: 1;
   display: flex;
   width: 100%;
   height: 100%;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1,111 +1,111 @@
 .chat-view-widget {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-tree-view-widget {
-    flex: 1;
+  flex: 1;
 }
 
-.chat-input-widget>.ps__rail-x,
-.chat-input-widget>.ps__rail-y {
-    display: none !important;
+.chat-input-widget > .ps__rail-x,
+.chat-input-widget > .ps__rail-y {
+  display: none !important;
 }
 
 .theia-ChatNode {
-    cursor: default;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding: 16px 20px;
-    user-select: text;
-    -webkit-user-select: text;
-    border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  user-select: text;
+  -webkit-user-select: text;
+  border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
 }
 
-div:last-child>.theia-ChatNode {
-    border: none;
+div:last-child > .theia-ChatNode {
+  border: none;
 }
 
 .theia-ChatNodeHeader {
-    align-items: center;
-    display: flex;
-    gap: 8px;
-    width: 100%;
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  width: 100%;
 }
 
 .theia-ChatNodeHeader .theia-AgentAvatar {
-    display: flex;
-    pointer-events: none;
-    user-select: none;
-    font-size: 20px;
+  display: flex;
+  pointer-events: none;
+  user-select: none;
+  font-size: 20px;
 }
 
 .theia-ChatNodeHeader .theia-AgentLabel {
-    font-size: 13px;
-    font-weight: 600;
-    margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
 }
 
 .theia-ChatNodeHeader .theia-ChatContentInProgress {
-    color: var(--theia-disabledForeground);
+  color: var(--theia-disabledForeground);
 }
 
 .theia-ChatNodeHeader .theia-ChatContentInProgress-Cancel {
-    position: absolute;
-    z-index: 999;
-    right: 20px;
+  position: absolute;
+  z-index: 999;
+  right: 20px;
 }
 
 @keyframes dots {
+  0%,
+  20% {
+    content: "";
+  }
 
-    0%,
-    20% {
-        content: '';
-    }
+  40% {
+    content: ".";
+  }
 
-    40% {
-        content: '.';
-    }
+  60% {
+    content: "..";
+  }
 
-    60% {
-        content: '..';
-    }
-
-    80%,
-    100% {
-        content: '...';
-    }
+  80%,
+  100% {
+    content: "...";
+  }
 }
 
 .theia-ChatNodeHeader .theia-ChatContentInProgress::after {
-    content: '';
-    animation: dots 1.0s steps(1, end) infinite;
+  content: "";
+  animation: dots 1s steps(1, end) infinite;
 }
 
 .theia-ChatNode .codicon {
-    text-align: left;
+  text-align: left;
 }
 
 .theia-AgentLabel {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .theia-ChatNode .rendered-markdown p {
-    margin: 0 0 16px;
+  margin: 0 0 16px;
 }
 
-.theia-ChatNode:last-child .rendered-markdown>:last-child {
-    margin-bottom: 0;
+.theia-ChatNode:last-child .rendered-markdown > :last-child {
+  margin-bottom: 0;
 }
 
 .theia-ChatNode .rendered-markdown {
-    line-height: 1.3rem;
+  line-height: 1.3rem;
 }
 
 .chat-input-widget {
-  align-items: center;
+  align-items: flex-end;
   display: flex;
+  flex-direction: column;
 }
 
 .theia-ChatInput {
@@ -115,103 +115,148 @@ div:last-child>.theia-ChatNode {
   gap: 4px;
 }
 
-.theia-ChatInput-Editor {
+.theia-ChatInput-Editor-Box {
+  margin-bottom: 2px;
   padding: 10px;
-  resize: none;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+.theia-ChatInput-Editor {
+  width: 100%;
+  height: auto;
+  border: var(--theia-border-width) solid var(--theia-dropdown-border);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column-reverse;
+  overflow: hidden;
+}
+
+.theia-ChatInput-Editor:has(.monaco-editor.focused) {
+  border-color: var(--theia-focusBorder);
+}
+
+.theia-ChatInput-Editor .monaco-editor {
+  flex-grow: 1;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.theia-ChatInput-Editor-Placeholder {
+  position: absolute;
+  top: -3px;
+  left: 19px;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  color: var(--theia-descriptionForeground);
+  pointer-events: none;
+  z-index: 10;
+  text-align: left;
+}
+.theia-ChatInput-Editor-Placeholder.hidden {
+  display: none;
 }
 
 .theia-ChatInput-Editor .monaco-editor .margin,
 .theia-ChatInput-Editor .monaco-editor .monaco-editor-background,
 .theia-ChatInput-Editor .monaco-editor .inputarea.ime-input {
-    padding-left: 8px !important;
+  padding-left: 8px !important;
 }
 
 .theia-ChatInputOptions {
   position: absolute;
-  bottom: 25px;
-  right: 20px;
+  bottom: 31px;
+  right: 26px;
   width: 10px;
   height: 10px;
 }
 
 .theia-ChatInputOptions .option {
-    width: 21px;
-    height: 21px;
-    margin-top: 2px;
-    display: inline-block;
-    box-sizing: border-box;
-    user-select: none;
-    background-repeat: no-repeat;
-    background-position: center;
-    border: var(--theia-border-width) solid transparent;
-    opacity: 0.7;
-    cursor: pointer;
+  width: 21px;
+  height: 21px;
+  margin-top: 2px;
+  display: inline-block;
+  box-sizing: border-box;
+  user-select: none;
+  background-repeat: no-repeat;
+  background-position: center;
+  border: var(--theia-border-width) solid transparent;
+  opacity: 0.7;
+  cursor: pointer;
 }
 
 .theia-ChatInputOptions .option:hover {
-    opacity: 1;
+  opacity: 1;
 }
 
 .theia-CodePartRenderer-root {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 .theia-CodePartRenderer-left {
-    flex-grow: 1;
+  flex-grow: 1;
 }
 
 .theia-CodePartRenderer-top {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-bottom: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 4px;
 }
 
 .theia-CodePartRenderer-right button {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 
 .theia-CodePartRenderer-separator {
-    width: 100%;
-    height: 1px;
-    background-color: #ccc;
+  width: 100%;
+  height: 1px;
+  background-color: #ccc;
 }
 
 .theia-toolCall {
-    font-weight: normal;
-    color: var(--theia-descriptionForeground);
-    line-height: 20px;
-    margin-bottom: 6px;
-    cursor: pointer;
+  font-weight: normal;
+  color: var(--theia-descriptionForeground);
+  line-height: 20px;
+  margin-bottom: 6px;
+  cursor: pointer;
 }
 
 .theia-toolCall .fa,
 .theia-toolCall details summary::marker {
-    color: var(--theia-button-background);
+  color: var(--theia-button-background);
 }
 
 .spinner {
-    display: inline-block;
-    animation: spin 2s linear infinite;
+  display: inline-block;
+  animation: spin 2s linear infinite;
 }
 
 @keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
+  0% {
+    transform: rotate(0deg);
+  }
 
-    100% {
-        transform: rotate(360deg);
-    }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .theia-ChatPart-Error {
-    display: flex;
-    flex-direction: row;
-    gap: 0.5em;
-    color: var(--theia-errorForeground);
+  display: flex;
+  flex-direction: row;
+  gap: 0.5em;
+  color: var(--theia-errorForeground);
 }


### PR DESCRIPTION
Improves the styling of the input field:
![image](https://github.com/user-attachments/assets/25ac9ba9-6152-4c73-86bd-9b79ea738573)


However what I didn't manage to properly integrate in an hour or so is to also adapt the size of the editor when the line breaks. I tried to call editor.getControl().layout(...) but this didn't change anything. The editor doesn't consume more space (with additional lines) even if it would have them after resizing the parent.
You can test that by typing a long sequence of words. With each line the container correctly increases its size, but the editor doesn't consume it.

Do you have an idea?