### PR TITLE
Use function calls in prompt templates

### DIFF
--- a/packages/ai-chat/src/common/chat-parsed-request.ts
+++ b/packages/ai-chat/src/common/chat-parsed-request.ts
@@ -20,7 +20,7 @@
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/editor/common/core/offsetRange.ts
 
-import { AIVariable, ResolvedAIVariable, ToolRequest } from '@theia/ai-core';
+import { AIVariable, ResolvedAIVariable, ToolRequest, toolRequestToPromptText } from '@theia/ai-core';
 import { ChatAgentData } from './chat-agents';
 import { ChatRequest } from './chat-model';
 
@@ -110,22 +110,7 @@ export class ChatRequestFunctionPart implements ChatRequestBasePart {
     }
 
     get promptText(): string {
-        const parameters = this.toolRequest.parameters;
-        let paramsText = '';
-        // parameters are supposed to be as a JSON schema. Thus, derive the parameters from its properties definition
-        if (parameters) {
-            const properties = parameters.properties;
-            paramsText = Object.keys(properties)
-                .map(key => {
-                    const param = properties[key];
-                    return `${key}: ${param.type}`;
-                })
-                .join(', ');
-        }
-        const descriptionText = this.toolRequest.description
-            ? `: ${this.toolRequest.description}`
-            : '';
-        return `You can call function: ${this.toolRequest.id}(${paramsText})${descriptionText}`;
+        return toolRequestToPromptText(this.toolRequest);
     }
 }
 

--- a/packages/ai-chat/src/common/command-chat-agents.ts
+++ b/packages/ai-chat/src/common/command-chat-agents.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { AbstractTextToModelParsingChatAgent } from './chat-agents';
+import { AbstractTextToModelParsingChatAgent, SystemMessage } from './chat-agents';
 import {
     PromptTemplate,
     LanguageModelRequirement
@@ -269,7 +269,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
 
     protected override languageModelPurpose = 'command';
 
-    protected async getSystemMessage(): Promise<string | undefined> {
+    protected async getSystemMessage(): Promise<SystemMessage | undefined> {
         const knownCommands: string[] = [];
         for (const command of this.commandRegistry.getAllCommands()) {
             knownCommands.push(`${command.id}: ${command.label}`);
@@ -280,7 +280,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
         if (systemPrompt === undefined) {
             throw new Error('Couldn\'t get system prompt ');
         }
-        return systemPrompt;
+        return SystemMessage.fromResolvedPromptTemplate(systemPrompt);
     }
 
     /**

--- a/packages/ai-chat/src/common/default-chat-agent.ts
+++ b/packages/ai-chat/src/common/default-chat-agent.ts
@@ -19,7 +19,7 @@ import {
     PromptTemplate
 } from '@theia/ai-core/lib/common';
 import { injectable } from '@theia/core/shared/inversify';
-import { AbstractStreamParsingChatAgent } from './chat-agents';
+import { AbstractStreamParsingChatAgent, SystemMessage } from './chat-agents';
 
 export const defaultTemplate: PromptTemplate = {
     id: 'default-template',
@@ -92,8 +92,9 @@ export class DefaultChatAgent extends AbstractStreamParsingChatAgent {
     variables: string[] = [];
     promptTemplates: PromptTemplate[] = [defaultTemplate];
 
-    protected async getSystemMessage(): Promise<string | undefined> {
-        return this.promptService.getPrompt(defaultTemplate.id);
-    }
+    protected async getSystemMessage(): Promise<SystemMessage | undefined> {
+      const resolvedPrompt = await this.promptService.getPrompt(defaultTemplate.id);
+      return resolvedPrompt ? SystemMessage.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
+   }
 
 }

--- a/packages/ai-chat/src/common/delegating-chat-agent.ts
+++ b/packages/ai-chat/src/common/delegating-chat-agent.ts
@@ -20,7 +20,7 @@ import {
 } from '@theia/ai-core/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
-import { AbstractStreamParsingChatAgent } from './chat-agents';
+import { AbstractStreamParsingChatAgent, SystemMessage } from './chat-agents';
 import { ChatRequestModelImpl, InformationalChatResponseContentImpl } from './chat-model';
 
 export const delegateTemplate: PromptTemplate = {
@@ -81,8 +81,9 @@ export class DelegatingChatAgent extends AbstractStreamParsingChatAgent {
     @inject(ChatAgentService)
     protected chatAgentService: ChatAgentService;
 
-    protected async getSystemMessage(): Promise<string | undefined> {
-        return this.promptService.getPrompt(delegateTemplate.id);
+    protected async getSystemMessage(): Promise<SystemMessage | undefined> {
+        const resolvedPrompt = await this.promptService.getPrompt(delegateTemplate.id);
+        return resolvedPrompt ? SystemMessage.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
     }
 
     protected override async addContentsToResponse(response: LanguageModelResponse, request: ChatRequestModelImpl): Promise<void> {

--- a/packages/ai-chat/src/common/delegating-chat-agent.ts
+++ b/packages/ai-chat/src/common/delegating-chat-agent.ts
@@ -87,7 +87,11 @@ export class DelegatingChatAgent extends AbstractStreamParsingChatAgent {
     }
 
     protected override async addContentsToResponse(response: LanguageModelResponse, request: ChatRequestModelImpl): Promise<void> {
-        let agentIds = (await getJsonOfResponse(response)).filter((id: string) => id !== this.id);
+        const jsonResponse = await getJsonOfResponse(response);
+        let agentIds = [];
+        if (Array.isArray(jsonResponse)) {
+            agentIds = jsonResponse.filter((id: string) => id !== this.id);
+        }
         if (agentIds.length < 1) {
             this.logger.error('No agent was selected, delegating to default chat agent');
             agentIds = ['DefaultChatAgent'];

--- a/packages/ai-code-completion/src/common/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/common/code-completion-agent.ts
@@ -79,7 +79,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
         if (token.isCancellationRequested) {
             return undefined;
         }
-        const prompt = await this.promptService.getPrompt('code-completion-prompt', { snippet, file, language });
+        const prompt = await this.promptService.getPrompt('code-completion-prompt', { snippet, file, language }).then(p => p?.text);
         if (!prompt) {
             console.error('No prompt found for code-completion-agent');
             return undefined;

--- a/packages/ai-code-fix/src/browser/code-fix-agent.ts
+++ b/packages/ai-code-fix/src/browser/code-fix-agent.ts
@@ -77,7 +77,15 @@ export class CodeFixAgentImpl implements CodeFixAgent {
             return [];
         }
 
-        const prompt = await this.promptService.getPrompt('code-fix-prompt', { contextRangeContent, file: fileName, language, errorMsg: errorMsg, lineNumber: lineNumber });
+        const prompt = await this.promptService
+            .getPrompt('code-fix-prompt', {
+                contextRangeContent,
+                file: fileName,
+                language,
+                errorMsg: errorMsg,
+                lineNumber: lineNumber,
+            })
+            .then(p => p?.text);
         if (!prompt) {
             console.error('No prompt found for code-fix-agent');
             return [];

--- a/packages/ai-core/data/prompttemplate.tmLanguage.json
+++ b/packages/ai-core/data/prompttemplate.tmLanguage.json
@@ -21,6 +21,27 @@
           "match": "[a-zA-Z_][a-zA-Z0-9_]*"
         }
       ]
+    },
+    {
+      "name": "support.function.prompttemplate",
+      "begin": "~{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.brace.begin"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.brace.end"
+        }
+      },
+      "patterns": [
+        {
+          "name": "keyword.control",
+          "match": "[a-zA-Z_][a-zA-Z0-9_\\-]*"
+        }
+      ]
     }
   ],
   "repository": {},

--- a/packages/ai-core/src/common/language-model-util.ts
+++ b/packages/ai-core/src/common/language-model-util.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelResponse } from './language-model';
+import { isLanguageModelStreamResponse, isLanguageModelTextResponse, LanguageModelResponse, ToolRequest } from './language-model';
 
 export const getTextOfResponse = async (response: LanguageModelResponse): Promise<string> => {
     if (isLanguageModelTextResponse(response)) {
@@ -46,4 +46,22 @@ export const getJsonOfResponse = async (response: LanguageModelResponse): Promis
         return JSON.parse(text);
     }
     throw new Error('Invalid response format');
+};
+export const toolRequestToPromptText = (toolRequest: ToolRequest<object>): string => {
+    const parameters = toolRequest.parameters;
+    let paramsText = '';
+    // parameters are supposed to be as a JSON schema. Thus, derive the parameters from its properties definition
+    if (parameters) {
+        const properties = parameters.properties;
+        paramsText = Object.keys(properties)
+            .map(key => {
+                const param = properties[key];
+                return `${key}: ${param.type}`;
+            })
+            .join(', ');
+    }
+    const descriptionText = toolRequest.description
+        ? `: ${toolRequest.description}`
+        : '';
+    return `You can call function: ${toolRequest.id}(${paramsText})${descriptionText}`;
 };

--- a/packages/ai-pr-finalization/src/browser/ai-pr-finalization-agent.ts
+++ b/packages/ai-pr-finalization/src/browser/ai-pr-finalization-agent.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AbstractStreamParsingChatAgent } from '@theia/ai-chat';
+import { AbstractStreamParsingChatAgent, SystemMessage } from '@theia/ai-chat';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { injectable } from '@theia/core/shared/inversify';
 
@@ -77,7 +77,8 @@ And here is my git-diff: #git-diff.
 
     protected override languageModelPurpose = 'chat';
 
-    protected override async getSystemMessage(): Promise<string | undefined> {
-        return this.promptTemplates.find(template => template.id === 'ai-pr-finalization:system-prompt')?.template;
+    protected override async getSystemMessage(): Promise<SystemMessage | undefined> {
+        const resolvedPrompt = await this.promptService.getPrompt('ai-pr-finalization:system-prompt');
+        return resolvedPrompt ? SystemMessage.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
     }
 }

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -122,8 +122,8 @@ recent-terminal-contents:
             return [];
         }
 
-        const systemPrompt = await this.promptService.getPrompt('ai-terminal:system-prompt', input);
-        const userPrompt = await this.promptService.getPrompt('ai-terminal:user-prompt', input);
+        const systemPrompt = await this.promptService.getPrompt('ai-terminal:system-prompt', input).then(p => p?.text);
+        const userPrompt = await this.promptService.getPrompt('ai-terminal:user-prompt', input).then(p => p?.text);
         if (!systemPrompt || !userPrompt) {
             this.logger.error('The prompt service didn\'t return prompts for the AI Terminal Agent.');
             return [];

--- a/packages/ai-workspace-agent/src/browser/workspace-agent.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-agent.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { AbstractStreamParsingChatAgent } from '@theia/ai-chat/lib/common';
+import { AbstractStreamParsingChatAgent, SystemMessage } from '@theia/ai-chat/lib/common';
 import { FunctionCallRegistry, LanguageModelRequirement, ToolRequest } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { template } from '../common/template';
@@ -40,8 +40,9 @@ finding out what this project is about, or how to implement certain aspects of b
     @inject(FunctionCallRegistry)
     protected functionCallRegistry: FunctionCallRegistry;
 
-    protected override getSystemMessage(): Promise<string | undefined> {
-        return this.promptService.getPrompt(template.id);
+    protected override async getSystemMessage(): Promise<SystemMessage | undefined> {
+        const resolvedPrompt = await this.promptService.getPrompt(template.id);
+        return resolvedPrompt ? SystemMessage.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
     }
 
     protected override getTools(): ToolRequest<object>[] | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

#### Parse functions in prompt templates and add to LLM calls

Extends the prompt service to parse function descriptions in format
`~{<id>}` from prompt templates and return them as part of the
resolved prompt.

To support returning tools besides the plain text for resolved prompts, the message signature of `PromptService.getPrompt`
now returns an object of new type ResolvedPromptTemplate.

Similarly, the `getSystemMessage` method of the`AbstractChatAgent` now also return an object.
The `AbstractChatAgent` is adapted to hand over system and
request function descriptions to the LLM.


#### Add highlighting and autocomplete for functions in prompt templates

Extends the prompt template language to add syntax highlighting and
autocompletion for llm functions.

With this, available functions are automatically shown after typing `~{`
and the curly brackets are auto closed.

<!-- Include relevant issues and describe how they are addressed. -->
Implements https://github.com/eclipsesource/osweek-2024/issues/95

### Screencast

[Screencast from 08-13-24 18:37:40.webm](https://github.com/user-attachments/assets/8f78f46f-1851-4e59-9df0-27178e8ccd68)

### How to test

- Edit a prompt template (e.g. of the default agent)
- type `~{`
- available functions should be suggested. Select one or two
- Save the template
- Use the agent and write a prompt that should invoke a tool.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
