### PR TITLE
Pass settings through to OpenAI

### DIFF
--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -62,13 +62,15 @@ export class OpenAiModel implements LanguageModel {
                 messages: request.messages.map(this.toOpenAIMessage),
                 stream: true,
                 tools: tools,
-                tool_choice: 'auto'
+                tool_choice: 'auto',
+                ...request.settings
             });
         } else {
             runner = openai.beta.chat.completions.stream({
                 model: this.model,
                 messages: request.messages.map(this.toOpenAIMessage),
                 stream: true,
+                ...request.settings
             });
         }
         request.cancellationToken?.onCancellationRequested(() => {


### PR DESCRIPTION
This e.g. allows an agent to set the `temperature`, etc.

Tested by adding the following to a LLM request:
```ts
const languageModelResponse = languageModel.request({
            messages,
            tools,
            cancellationToken: token,
            settings: {
                temperature: 0,
            }
});
```