### PR TITLE
Reference functions in workspace agent template

### DIFF
--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -19,13 +19,14 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID } from '../common/functions';
 
 /**
  * A Function that can read the contents of a File from the Workspace.
  */
 @injectable()
 export class FileContentFunction implements ToolProvider {
-    static ID = 'getFileContent';
+    static ID = FILE_CONTENT_FUNCTION_ID;
 
     getTool(): ToolRequest<object> {
         return {
@@ -71,7 +72,7 @@ export class FileContentFunction implements ToolProvider {
  */
 @injectable()
 export class GetWorkspaceFileList implements ToolProvider {
-    static ID = 'getWorkspaceFileList';
+    static ID = GET_WORKSPACE_FILE_LIST_FUNCTION_ID;
 
     getTool(): ToolRequest<object> {
         return {

--- a/packages/ai-workspace-agent/src/browser/workspace-agent.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-agent.ts
@@ -14,10 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { AbstractStreamParsingChatAgent, SystemMessage } from '@theia/ai-chat/lib/common';
-import { FunctionCallRegistry, LanguageModelRequirement, ToolRequest } from '@theia/ai-core';
+import { FunctionCallRegistry, LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { template } from '../common/template';
-import { FileContentFunction, GetWorkspaceFileList } from './functions';
 
 @injectable()
 export class WorkspaceAgent extends AbstractStreamParsingChatAgent {
@@ -43,9 +42,5 @@ finding out what this project is about, or how to implement certain aspects of b
     protected override async getSystemMessage(): Promise<SystemMessage | undefined> {
         const resolvedPrompt = await this.promptService.getPrompt(template.id);
         return resolvedPrompt ? SystemMessage.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
-    }
-
-    protected override getTools(): ToolRequest<object>[] | undefined {
-        return this.functionCallRegistry.getFunctions(GetWorkspaceFileList.ID, FileContentFunction.ID);
     }
 }

--- a/packages/ai-workspace-agent/src/common/functions.ts
+++ b/packages/ai-workspace-agent/src/common/functions.ts
@@ -13,17 +13,5 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { PromptTemplate } from '@theia/ai-core/lib/common';
-import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID } from './functions';
-
-export const template = <PromptTemplate>{
-    id: 'workspace-prompt',
-    template: `You are an AI Agent to help developers with coding inside of the IDE.
-    The user has the workspace open.
-    If needed, you can ask for more information.
-    The following functions are available to you:
-    - ~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}
-    - ~{${FILE_CONTENT_FUNCTION_ID}}
-
-Never shorten the file paths when using getFileContent.`
-};
+export const FILE_CONTENT_FUNCTION_ID = 'getFileContent';
+export const GET_WORKSPACE_FILE_LIST_FUNCTION_ID = 'getWorkspaceFileList';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- References the functions available to the workspace agent in its template
- Remove obsolete override of getTools method in the workspace agent. With this, additional tools can be given in the user message.

Relates to https://github.com/eclipsesource/osweek-2024/issues/95
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Use the workspace agent and prompt it in a way so that it wants to invoke its functions: E.g. something like:
```
@Workspace list all workspace files and describe their contents
```
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
