### PR TITLE
Add basic support for structured output

### DIFF
--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -26,6 +26,7 @@ import {
 } from '@theia/output/lib/browser/output-channel';
 import {
     DefaultLanguageModelRegistryImpl,
+    isLanguageModelParsedResponse,
     isLanguageModelStreamResponse,
     isLanguageModelStreamResponseDelegate,
     isLanguageModelTextResponse,
@@ -215,7 +216,7 @@ export class FrontendLanguageModelRegistryImpl
                     request,
                     requestId
                 );
-                if (isLanguageModelTextResponse(response)) {
+                if (isLanguageModelTextResponse(response) || isLanguageModelParsedResponse(response)) {
                     return response;
                 }
                 if (isLanguageModelStreamResponseDelegate(response)) {

--- a/packages/ai-core/src/common/language-model-delegate.ts
+++ b/packages/ai-core/src/common/language-model-delegate.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelMetaData, LanguageModelRequest, LanguageModelStreamResponsePart, LanguageModelTextResponse } from './language-model';
+import { LanguageModelMetaData, LanguageModelParsedResponse, LanguageModelRequest, LanguageModelStreamResponsePart, LanguageModelTextResponse } from './language-model';
 
 export const LanguageModelDelegateClient = Symbol('LanguageModelDelegateClient');
 export interface LanguageModelDelegateClient {
@@ -32,7 +32,7 @@ export interface LanguageModelStreamResponseDelegate {
 export const isLanguageModelStreamResponseDelegate = (obj: unknown): obj is LanguageModelStreamResponseDelegate =>
     !!(obj && typeof obj === 'object' && 'streamId' in obj && typeof (obj as { streamId: unknown }).streamId === 'string');
 
-export type LanguageModelResponseDelegate = LanguageModelTextResponse | LanguageModelStreamResponseDelegate;
+export type LanguageModelResponseDelegate = LanguageModelTextResponse | LanguageModelParsedResponse | LanguageModelStreamResponseDelegate;
 
 export const LanguageModelFrontendDelegate = Symbol('LanguageModelFrontendDelegate');
 export interface LanguageModelFrontendDelegate {

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -42,8 +42,18 @@ export interface ToolRequest<T extends object> {
 export interface LanguageModelRequest {
     messages: LanguageModelRequestMessage[],
     tools?: ToolRequest<object>[];
+    response_format?: { type: 'text' } | { type: 'json_object' } | ResponseFormatJsonSchema;
     cancellationToken?: CancellationToken;
     settings?: { [key: string]: unknown };
+}
+export interface ResponseFormatJsonSchema {
+    type: 'json_schema';
+    json_schema: {
+        name: string,
+        description?: string,
+        schema?: Record<string, unknown>,
+        strict?: boolean | null
+    };
 }
 
 export interface LanguageModelTextResponse {
@@ -73,7 +83,14 @@ export interface LanguageModelStreamResponse {
 export const isLanguageModelStreamResponse = (obj: unknown): obj is LanguageModelStreamResponse =>
     !!(obj && typeof obj === 'object' && 'stream' in obj);
 
-export type LanguageModelResponse = LanguageModelTextResponse | LanguageModelStreamResponse;
+export interface LanguageModelParsedResponse {
+    parsed: unknown;
+    content: string;
+}
+export const isLanguageModelParsedResponse = (obj: unknown): obj is LanguageModelParsedResponse =>
+    !!(obj && typeof obj === 'object' && 'parsed' in obj && 'content' in obj);
+
+export type LanguageModelResponse = LanguageModelTextResponse | LanguageModelStreamResponse | LanguageModelParsedResponse;
 
 ///////////////////////////////////////////
 // Language Model Provider

--- a/packages/ai-core/src/node/language-model-frontend-delegate.ts
+++ b/packages/ai-core/src/node/language-model-frontend-delegate.ts
@@ -28,6 +28,7 @@ import {
     LanguageModelRegistryFrontendDelegate,
     LanguageModelResponseDelegate,
     LanguageModelRegistryClient,
+    isLanguageModelParsedResponse,
 } from '../common';
 import { BackendLanguageModelRegistry } from './backend-language-model-registry';
 
@@ -86,7 +87,7 @@ export class LanguageModelFrontendDelegateImpl implements LanguageModelFrontendD
             this.requestCancellationTokenMap.set(requestId, tokenSource);
         }
         const response = await model.request(request);
-        if (isLanguageModelTextResponse(response)) {
+        if (isLanguageModelTextResponse(response) || isLanguageModelParsedResponse(response)) {
             return response;
         }
         if (isLanguageModelStreamResponse(response)) {

--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -8,7 +8,7 @@
     "@theia/workspace": "1.52.0",
     "minimatch": "^5.1.0",
     "tslib": "^2.6.2",
-    "openai": "^4.45.0",
+    "openai": "^4.55.7",
     "@theia/ai-core": "1.52.0"
   },
   "publishConfig": {

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -14,10 +14,17 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModel, LanguageModelRequest, LanguageModelRequestMessage, LanguageModelResponse, LanguageModelStreamResponsePart } from '@theia/ai-core';
+import {
+    LanguageModel,
+    LanguageModelParsedResponse,
+    LanguageModelRequest,
+    LanguageModelRequestMessage,
+    LanguageModelResponse,
+    LanguageModelStreamResponsePart
+} from '@theia/ai-core';
 import OpenAI from 'openai';
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
-import { BaseFunctionsArgs, RunnableToolFunctionWithoutParse, RunnableTools } from 'openai/lib/RunnableFunction';
+import { RunnableToolFunctionWithoutParse } from 'openai/lib/RunnableFunction';
 import { ChatCompletionMessageParam } from 'openai/resources';
 
 export const OpenAiModelIdentifier = Symbol('OpenAiModelIdentifier');
@@ -39,23 +46,14 @@ export class OpenAiModel implements LanguageModel {
     }
 
     async request(request: LanguageModelRequest): Promise<LanguageModelResponse> {
-        const key = this.apiKey();
-        if (!key) {
-            throw new Error('Please provide OPENAI_API_KEY in preferences or via environment variable');
-        }
-        const openai = new OpenAI({ apiKey: key });
+        const openai = this.initializeOpenAi();
 
-        const tools: RunnableTools<BaseFunctionsArgs> | undefined = request.tools?.map(tool => ({
-            type: 'function',
-            function: {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters,
-                function: (args_string: string) => tool.handler(args_string)
-            }
-        } as RunnableToolFunctionWithoutParse
-        ));
+        if (request.response_format?.type === 'json_schema') {
+            return this.handleStructuredOutputRequest(openai, request);
+        }
+
         let runner: ChatCompletionStream;
+        const tools = this.createTools(request);
         if (tools) {
             runner = openai.beta.chat.completions.runTools({
                 model: this.model,
@@ -85,7 +83,7 @@ export class OpenAiModel implements LanguageModel {
         });
         runner.on('message', message => {
             if (message.role === 'tool') {
-                resolve({ tool_calls: [{ id: message.tool_call_id, finished: true, result: message.content }] });
+                resolve({ tool_calls: [{ id: message.tool_call_id, finished: true, result: this.getCompletionContent(message) }] });
             }
             console.log('Message:', JSON.stringify(message));
         });
@@ -109,6 +107,51 @@ export class OpenAiModel implements LanguageModel {
             }
         })();
         return { stream: asyncIterator };
+    }
+
+    protected async handleStructuredOutputRequest(openai: OpenAI, request: LanguageModelRequest): Promise<LanguageModelParsedResponse> {
+        // TODO implement tool support for structured output (parse() seems to require different tool format)
+        const result = await openai.beta.chat.completions.parse({
+            model: this.model,
+            messages: request.messages.map(this.toOpenAIMessage),
+            response_format: request.response_format,
+            ...request.settings
+        });
+        const message = result.choices[0].message;
+        if (message.refusal || message.parsed === undefined) {
+            console.error('Error in OpenAI chat completion stream:', JSON.stringify(message));
+        }
+        return {
+            content: message.content ?? '',
+            parsed: message.parsed
+        };
+    }
+
+    private getCompletionContent(message: OpenAI.Chat.Completions.ChatCompletionToolMessageParam): string {
+        if (Array.isArray(message.content)) {
+            return message.content.join('');
+        }
+        return message.content;
+    }
+
+    protected createTools(request: LanguageModelRequest): RunnableToolFunctionWithoutParse[] | undefined {
+        return request.tools?.map(tool => ({
+            type: 'function',
+            function: {
+                name: tool.name,
+                description: tool.description,
+                parameters: tool.parameters,
+                function: (args_string: string) => tool.handler(args_string)
+            }
+        } as RunnableToolFunctionWithoutParse));
+    }
+
+    protected initializeOpenAi(): OpenAI {
+        const key = this.apiKey();
+        if (!key) {
+            throw new Error('Please provide OPENAI_API_KEY in preferences or via environment variable');
+        }
+        return new OpenAI({ apiKey: key });
     }
 
     private toOpenAIMessage(message: LanguageModelRequestMessage): ChatCompletionMessageParam {

--- a/packages/ai-terminal/package.json
+++ b/packages/ai-terminal/package.json
@@ -6,7 +6,9 @@
     "@theia/core": "1.52.0",
     "@theia/ai-core": "1.52.0",
     "@theia/ai-chat": "1.52.0",
-    "@theia/terminal": "1.52.0"
+    "@theia/terminal": "1.52.0",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.2"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9230,10 +9230,23 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openai@^4.41.1, openai@^4.45.0, openai@^4.49.1:
+openai@^4.41.1, openai@^4.49.1:
   version "4.53.2"
   resolved "https://registry.yarnpkg.com/openai/-/openai-4.53.2.tgz#86f54a38091a87db36f651cf28c9e5ee7c98d56a"
   integrity sha512-ohYEv6OV3jsFGqNrgolDDWN6Ssx1nFg6JDJQuaBFo4SL2i+MBoOQ16n2Pq1iBF5lH1PKnfCIOfqAGkmzPvdB9g==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+
+openai@^4.55.7:
+  version "4.55.7"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.55.7.tgz#2bba4ae9224ad205c0d087d1412fe95421397dff"
+  integrity sha512-I2dpHTINt0Zk+Wlns6KzkKu77MmNW3VfIIQf5qYziEUI6t7WciG1zTobfKqdPzBmZi3TTM+3DtjPumxQdcvzwA==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"
@@ -12854,12 +12867,12 @@ zip-stream@^4.1.0:
     compress-commons "^4.1.2"
     readable-stream "^3.6.0"
 
-zod-to-json-schema@^3.22.3:
+zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.23.2:
   version "3.23.2"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.2.tgz#bc7e379c8050462538383e382964c03d8fe008f9"
   integrity sha512-uSt90Gzc/tUfyNqxnjlfBs8W6WSGpNBv0rVsNxP/BVSMHMKGdthPYff4xtCHYloJGM0CFxFsb3NbC0eqPhfImw==
 
-zod@^3.22.4:
+zod@^3.22.4, zod@^3.23.8:
   version "3.23.8"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
Adds structured output support by providing a `result_format` to the LM request and pass it to the `parse()` method of OpenAI. To demonstrate the usage, I've used this in the terminal command agent.

Also we upgrade the OpenAI library with this change, to make this new API available.

Follow-ups:
- Support tool calls (it requires a slightly different format, it seems)
- Add type safety to avoid having to cast the parsed result