### PR TITLE
Initial fix for cancel button issue

### DIFF
--- a/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/aichat-ui-frontend-module.ts
@@ -47,19 +47,19 @@ export default new ContainerModule((bind, _ubind, _isBound, rebind) => {
     bindChatViewWidget(bind);
 
     bind(ChatInputWidget).toSelf();
-    bind(WidgetFactory).toDynamicValue(context => ({
+    bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: ChatInputWidget.ID,
-        createWidget: () => context.container.get<ChatInputWidget>(ChatInputWidget)
+        createWidget: () => container.get(ChatInputWidget)
     })).inSingletonScope();
 
     bind(ChatViewTreeWidget).toDynamicValue(ctx =>
         createChatViewTreeWidget(ctx.container)
     );
-
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: ChatViewTreeWidget.ID,
         createWidget: () => container.get(ChatViewTreeWidget)
     })).inSingletonScope();
+
     bind(ChatResponsePartRenderer).to(HorizontalLayoutPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(ErrorPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(MarkdownPartRenderer).inSingletonScope();

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -51,6 +51,7 @@ export class ChatInputWidget extends ReactWidget {
     private _chatModel: ChatModel;
     set chatModel(chatModel: ChatModel) {
         this._chatModel = chatModel;
+        this.update();
     }
 
     @postConstruct()

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -111,6 +111,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
                 if (session) {
                     this.chatSession = session;
                     this.treeWidget.trackChatModel(this.chatSession.model);
+                    this.inputWidget.chatModel = this.chatSession.model;
                     if (event.focus) {
                         this.show();
                     }


### PR DESCRIPTION
Follow-up: properly follow submit/cancel button when switching back and forth between generating chats.