### PR TITLE
Make terminal agent more versatile to variations in LLMs

### DIFF
--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -48,7 +48,7 @@ export class OpenAiModel implements LanguageModel {
     async request(request: LanguageModelRequest): Promise<LanguageModelResponse> {
         const openai = this.initializeOpenAi();
 
-        if (request.response_format?.type === 'json_schema') {
+        if (request.response_format?.type === 'json_schema' && this.supportsStructuredOutput()) {
             return this.handleStructuredOutputRequest(openai, request);
         }
 
@@ -110,6 +110,12 @@ export class OpenAiModel implements LanguageModel {
             }
         };
         return { stream: asyncIterator };
+    }
+
+    protected supportsStructuredOutput(): boolean {
+        // currently only the lastest 4o and 4o-mini models support structured output
+        // see https://platform.openai.com/docs/guides/structured-outputs
+        return this.model === 'gpt-4o-2024-08-06' || this.model === 'gpt-4o-mini';
     }
 
     protected async handleStructuredOutputRequest(openai: OpenAI, request: LanguageModelRequest): Promise<LanguageModelParsedResponse> {

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -16,6 +16,7 @@
 
 import {
     Agent,
+    getJsonOfResponse,
     isLanguageModelParsedResponse,
     LanguageModelRegistry, LanguageModelRequirement,
     PromptService
@@ -162,12 +163,24 @@ recent-terminal-contents:
                     }
                 }
             });
-            if (!isLanguageModelParsedResponse(result)) {
-                this.logger.error('Failed to parse the response from the language model.', result);
-                return [];
+
+            if (isLanguageModelParsedResponse(result)) {
+                // model returned structured output
+                const parsedResult = Commands.safeParse(result.parsed);
+                if (parsedResult.success) {
+                    return parsedResult.data.commands;
+                }
             }
-            const commandsObject = result.parsed as Commands;
-            return commandsObject.commands;
+
+            // fall back to agent-based parsing of result
+            const jsonResult = await getJsonOfResponse(result);
+            const parsedJsonResult = Commands.safeParse(jsonResult);
+            if (parsedJsonResult.success) {
+                return parsedJsonResult.data.commands;
+            }
+
+            return [];
+
         } catch (error) {
             this.logger.error('Error obtaining the command suggestions.', error);
             return [];

--- a/packages/ai-terminal/src/browser/ai-terminal-contribution.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-contribution.ts
@@ -156,7 +156,10 @@ class AiTerminalChatWidget {
             if (this.commands.length > 0) {
                 this.chatResultParagraph.className = 'command';
                 this.chatResultParagraph.innerText = this.commands[0];
-                this.chatInput.placeholder = 'Hit enter to confirm or use ⇅ to show alternatives...';
+                this.chatInput.placeholder = 'Hit enter to confirm';
+                if (this.commands.length > 1) {
+                    this.chatInput.placeholder += ' or use ⇅ to show alternatives...';
+                }
                 this.haveResult = true;
             } else {
                 this.chatResultParagraph.className = '';


### PR DESCRIPTION
#### What it does

* If the LLM doesn't return a parsed result, we try parsing the result in the agent
* makes cast more safe also in the parsed result case using zod

Additional improvements:
* only show hint for alternatives in the UI only if we have more than one result
* fall back to non-structured-output for all OpenAI models that don't support it

#### How to test

Use the AI terminal with different models that support or don't support structured output (e.g. gpt-4o vs gpt-4o-mini vs gpt-3.5-turbo). All of these models should now work equally fine, while gpt-4o-mini should benefit from structured output and others are parsed in the agent.

#### Follow-ups

N/A

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
