### PR TITLE
Add and use chatAgents variable in Delegating Chat Agent

### DIFF
--- a/packages/ai-chat/src/browser/agent-frontend-module.ts
+++ b/packages/ai-chat/src/browser/agent-frontend-module.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Agent } from '@theia/ai-core/lib/common';
+import { Agent, AIVariableContribution } from '@theia/ai-core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
@@ -29,6 +29,7 @@ import {
 import { CommandChatAgent } from '../common/command-chat-agents';
 import { DelegatingChatAgent } from '../common/delegating-chat-agent';
 import { DefaultChatAgent } from '../common/default-chat-agent';
+import { ChatAgentsVariableContribution } from '../common/chat-agents-variable-contribution';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -36,6 +37,8 @@ export default new ContainerModule(bind => {
 
     bind(ChatAgentServiceImpl).toSelf().inSingletonScope();
     bind(ChatAgentService).toService(ChatAgentServiceImpl);
+
+    bind(AIVariableContribution).to(ChatAgentsVariableContribution).inSingletonScope();
 
     bind(ChatRequestParserImpl).toSelf().inSingletonScope();
     bind(ChatRequestParser).toService(ChatRequestParserImpl);

--- a/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
+++ b/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
@@ -71,6 +71,17 @@ export class ChatAgentsVariableContribution implements AIVariableContribution, A
             name: agent.name,
             description: agent.description
         }));
-        return { variable: CHAT_AGENTS_VARIABLE, agents, value: JSON.stringify(agents) };
+        const value = agents.map(agent => prettyPrintInMd(agent)).join('\n');
+        return { variable: CHAT_AGENTS_VARIABLE, agents, value };
     }
 }
+
+function prettyPrintInMd(agent: { id: string; name: string; description: string; }): string {
+    return `
+* ${agent.id}
+  * *ID*: ${agent.id}
+  * *Name*: ${agent.name}
+  * *Description*: ${agent.description.replace(/\n/g, ' ')}
+`;
+}
+

--- a/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
+++ b/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { MaybePromise } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import {
+    AIVariable,
+    AIVariableContext,
+    AIVariableContribution,
+    AIVariableResolutionRequest,
+    AIVariableResolver,
+    AIVariableService,
+    ResolvedAIVariable
+} from '../../../ai-core/src/common/variable-service';
+import { ChatAgentService } from './chat-agent-service';
+
+export const CHAT_AGENTS_VARIABLE: AIVariable = {
+    id: 'chatAgents',
+    name: 'chatAgents',
+    description: 'Returns the list of chat agents available in the system'
+};
+
+export interface ResolvedChatAgentsVariable extends ResolvedAIVariable {
+    agents: ChatAgentDescriptor[];
+}
+
+export interface ChatAgentDescriptor {
+    id: string;
+    name: string;
+    description: string;
+}
+
+@injectable()
+export class ChatAgentsVariableContribution implements AIVariableContribution, AIVariableResolver {
+
+    @inject(ChatAgentService)
+    protected readonly agents: ChatAgentService;
+
+    registerVariables(service: AIVariableService): void {
+        service.registerResolver(CHAT_AGENTS_VARIABLE, this);
+    }
+
+    canResolve(request: AIVariableResolutionRequest, _context: AIVariableContext): MaybePromise<number> {
+        if (request.variable.name === CHAT_AGENTS_VARIABLE.name) {
+            return 1;
+        }
+        return -1;
+    }
+
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+        if (request.variable.name === CHAT_AGENTS_VARIABLE.name) {
+            return this.resolveAgentsVariable(request);
+        }
+    }
+
+    resolveAgentsVariable(_request: AIVariableResolutionRequest): ResolvedChatAgentsVariable {
+        const agents = this.agents.getAgents().map(agent => ({
+            id: agent.id,
+            name: agent.name,
+            description: agent.description
+        }));
+        return { variable: CHAT_AGENTS_VARIABLE, agents, value: JSON.stringify(agents) };
+    }
+}

--- a/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
+++ b/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
@@ -77,11 +77,9 @@ export class ChatAgentsVariableContribution implements AIVariableContribution, A
 }
 
 function prettyPrintInMd(agent: { id: string; name: string; description: string; }): string {
-    return `
-* ${agent.id}
-  * *ID*: ${agent.id}
-  * *Name*: ${agent.name}
-  * *Description*: ${agent.description.replace(/\n/g, ' ')}
-`;
+    return `- ${agent.id}
+  - *ID*: ${agent.id}
+  - *Name*: ${agent.name}
+  - *Description*: ${agent.description.replace(/\n/g, ' ')}`;
 }
 

--- a/packages/ai-chat/src/common/delegating-chat-agent.ts
+++ b/packages/ai-chat/src/common/delegating-chat-agent.ts
@@ -55,10 +55,8 @@ You must only use the \`id\` attribute of the agent, never the name.
 
 ## List of Currently Available Chat Agents
 
-\${agents}
-
-`
-};
+\${chatAgents}
+`};
 
 @injectable()
 export class DelegatingChatAgent extends AbstractStreamParsingChatAgent {
@@ -69,7 +67,7 @@ export class DelegatingChatAgent extends AbstractStreamParsingChatAgent {
 
     override iconClass = 'codicon codicon-symbol-boolean';
 
-    variables: string[] = ['agents'];
+    variables: string[] = ['chatAgents'];
     promptTemplates: PromptTemplate[] = [delegateTemplate];
 
     languageModelPurpose = 'agent-selection';


### PR DESCRIPTION
#### What it does

* Add \chatAgents that only includes actual chat agents not all agents
* Use \chatAgents instead of \agents in Delegating Chat Agent to avoid delegating to non-chat agents

#### How to test

Test that delegating chat agent never delegates to a non-chat agent (e.g. terminal agent).
Also you can inspect the system prompt after it has been resolved with variables in the delegating chat agent (see delegating-chat-agent.ts:89).

#### Follow-ups

N/A

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
