### PR TITLE
Change prompt template variable marker to `{{variable}}`

### DIFF
--- a/packages/ai-chat/src/common/command-chat-agents.ts
+++ b/packages/ai-chat/src/common/command-chat-agents.ts
@@ -123,7 +123,7 @@ If there are no more command ids that seem to fit, return a response of \`"type"
 Here are the known Theia commands:
 
 Begin List:
-\${command-ids}
+{{command-ids}}
 End List
 
 You may only use commands from this list when responding with \`"type": "theia-command"\`.

--- a/packages/ai-chat/src/common/delegating-chat-agent.ts
+++ b/packages/ai-chat/src/common/delegating-chat-agent.ts
@@ -55,7 +55,7 @@ You must only use the \`id\` attribute of the agent, never the name.
 
 ## List of Currently Available Chat Agents
 
-\${agents}
+{{agents}}
 
 `
 };

--- a/packages/ai-code-completion/src/common/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/common/code-completion-agent.ts
@@ -138,11 +138,11 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     promptTemplates: PromptTemplate[] = [
         {
             id: 'code-completion-prompt',
-            template: `You are a code completion agent. The current file you have to complete is named \${file}.
-The language of the file is \${language}. Return your result as plain text without markdown formatting.
+            template: `You are a code completion agent. The current file you have to complete is named {{file}}.
+The language of the file is {{language}}. Return your result as plain text without markdown formatting.
 Finish the following code snippet.
 
-\${snippet}
+{{snippet}}
 
 Only return the exact replacement for {{MARKER}} to complete the snippet.`,
         }

--- a/packages/ai-core/data/prompttemplate.tmLanguage.json
+++ b/packages/ai-core/data/prompttemplate.tmLanguage.json
@@ -3,13 +3,13 @@
   "patterns": [
     {
       "name": "variable.other.prompttemplate",
-      "begin": "\\${",
+      "begin": "{{",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.brace.begin"
         }
       },
-      "end": "}",
+      "end": "}}",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.brace.end"

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -49,7 +49,7 @@ export interface PromptService {
      */
     getDefaultRawPrompt(id: string): PromptTemplate | undefined;
     /**
-     * Allows to directly replace placeholders in the prompt. The supported format is 'Hi ${name}!'.
+     * Allows to directly replace placeholders in the prompt. The supported format is 'Hi {{name}}!'.
      * The placeholder is then searched inside the args object and replaced.
      * Function references are also supported via format '~{functionId}'.
      * @param id the id of the prompt
@@ -105,8 +105,8 @@ export interface PromptCustomizationService {
     getTemplateIDFromURI(uri: URI): string | undefined;
 }
 
-// should match the one from VariableResolverService
-const PROMPT_VARIABLE_REGEX = /\$\{(.*?)\}/g;
+// should match the one from VariableResolverService. The format is {{variableName:arg}}
+const PROMPT_VARIABLE_REGEX = /\{\{(.*?)\}\}/g;
 
 // Match function/tool references in the prompt. The format is ~{functionId}
 const PROMPT_FUNCTION_REGEX = /\~\{(.*?)\}/g;

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -93,11 +93,11 @@ nothing to commit, working tree clean
             name: 'AI Terminal User Prompt',
             description: 'Prompt that contains the user request',
             template: `
-user-request: \${userRequest}
-shell: \${shell}
-cwd: \${cwd}
+user-request: {{userRequest}}
+shell: {{shell}}
+cwd: {{cwd}}
 recent-terminal-contents:
-\${recentTerminalContents}
+{{recentTerminalContents}}
 `
         }
     ];


### PR DESCRIPTION
#### What it does

It seems that `{{variable}}` is more common as a variable marker in prompt templates, if you look at prompting consoles (like the one for claude). Also omitting the `$` is less cumbersome to write, as we don't need to escape the `$` if we put the variables in expression strings.

This PR changes the marker for variables in prompt templates.

#### How to test

Everything should work as before.

#### Follow-ups

N/A

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
