### PR TITLE
Harden delegation and fix prompts collection

### DIFF
--- a/packages/ai-chat/src/browser/frontend-chat-service.ts
+++ b/packages/ai-chat/src/browser/frontend-chat-service.ts
@@ -36,11 +36,21 @@ export class FrontendChatServiceImpl extends ChatServiceImpl {
             return configuredDefaultChatAgent;
         }
 
-        if (this.defaultChatAgent) {
-            return this.chatAgentService.getAgent(this.defaultChatAgent.id);
+        if (this.defaultChatAgentId) {
+            const defaultAgent = this.chatAgentService.getAgent(this.defaultChatAgentId.id);
+            // the default agent could be disabled
+            if (defaultAgent) {
+                return defaultAgent;
+            }
         }
 
-        this.logger.warn('No default chat agent is configured. Falling back to first registered agent.');
+        // check whether "Universal" is available
+        const universalAgent = this.chatAgentService.getAgent('Universal');
+        if (universalAgent) {
+            return universalAgent;
+        }
+
+        this.logger.warn('No default chat agent is configured or available and the "Universal" Chat Agent is unavailable too. Falling back to first registered agent.');
 
         return this.chatAgentService.getAgents()[0] ?? undefined;
     }

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -97,7 +97,7 @@ export class ChatServiceImpl implements ChatService {
     protected chatAgentService: ChatAgentService;
 
     @inject(DefaultChatAgentId) @optional()
-    protected defaultChatAgent: DefaultChatAgentId | undefined;
+    protected defaultChatAgentId: DefaultChatAgentId | undefined;
 
     @inject(ChatRequestParser)
     protected chatRequestParser: ChatRequestParser;
@@ -233,8 +233,8 @@ export class ChatServiceImpl implements ChatService {
         if (agentPart) {
             return this.chatAgentService.getAgent(agentPart.agent.id);
         }
-        if (this.defaultChatAgent) {
-            return this.chatAgentService.getAgent(this.defaultChatAgent.id);
+        if (this.defaultChatAgentId) {
+            return this.chatAgentService.getAgent(this.defaultChatAgentId.id);
         }
         return this.chatAgentService.getAgents()[0] ?? undefined;
     }

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -63,7 +63,7 @@ export const OrchestratorChatAgentId = 'Orchestrator';
 @injectable()
 export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent {
     id: string = OrchestratorChatAgentId;
-    name: string = 'Orchestrator';
+    name: string = OrchestratorChatAgentId;
     description: string = 'This agent analyzes the user request against the description of all available chat agents and selects the best fitting agent to answer the request \
         (by using AI). The user\'s request will be directly delegated to the selected agent without further confirmation.';
 


### PR DESCRIPTION
#### What it does

- fix: harden default chat agent fallback
- align orchestrator name and id
- rename default chat agent id variable to better convey its content
- fix: make sure templates are consistently consumed

#### How to test

**Hardening**
- Disable Orchestrator and post a query. Without the hardening this will fail. With the hardening we will properly fallback to either "Universal" or any other chat agent

**Prompts**
- Customize the "Universal" prompt when templates folder is not configured, e.g. add "talk like a pirate". Also feel free to customize more prompts there
- Customize the prompt folder
- Do NOT customize the "universal" prompt in the configured folder
- Restart the tool
- Send a query. For me the customized prompt from the default folder was used, not the actual default which should have been used as I did not customize the universal prompt in my custom folder.

When debugging I noticed that "update" runs twice very fast behind each other as the "preferences" will first notify their default value (empty) which resolved to the default theia folder, immediately followed by the customized folder. As both are heavy on awaits, the original folder still added templates to the cache although it was already outdated.