### PR TITLE
feat: persist perspective layouts

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -146,8 +146,7 @@ import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-st
 import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 import { CorePreferences, bindCorePreferences } from '../common/core-preferences';
 import { bindBadgeDecoration } from './badges';
-import { PerspectiveContribution, PerspectiveService } from './perspective-service';
-import { PerspectiveLayoutProvider } from './shell/shell-layout-restorer';
+import { PerspectiveContribution, PerspectiveService, PerspectiveServiceImpl } from './perspective-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -485,10 +484,10 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(DomInputUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(DomInputUndoRedoHandler);
 
-    bind(PerspectiveService).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(PerspectiveService);
-    bind(CommandContribution).toService(PerspectiveService);
-    bind(PerspectiveLayoutProvider).toService(PerspectiveService);
+    bind(PerspectiveServiceImpl).toSelf().inSingletonScope();
+    bind(PerspectiveService).toService(PerspectiveServiceImpl);
+    bind(FrontendApplicationContribution).toService(PerspectiveServiceImpl);
+    bind(CommandContribution).toService(PerspectiveServiceImpl);
     bindRootContributionProvider(bind, PerspectiveContribution);
 
     bind(WidgetStatusBarService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -147,6 +147,7 @@ import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 import { CorePreferences, bindCorePreferences } from '../common/core-preferences';
 import { bindBadgeDecoration } from './badges';
 import { PerspectiveContribution, PerspectiveService } from './perspective-service';
+import { PerspectiveLayoutProvider } from './shell/shell-layout-restorer';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -487,6 +488,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(PerspectiveService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(PerspectiveService);
     bind(CommandContribution).toService(PerspectiveService);
+    bind(PerspectiveLayoutProvider).toService(PerspectiveService);
     bindRootContributionProvider(bind, PerspectiveContribution);
 
     bind(WidgetStatusBarService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -19,13 +19,13 @@ const disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { PerspectiveService, PerspectiveDescriptor } from './perspective-service';
+import { PerspectiveServiceImpl, PerspectiveDescriptor } from './perspective-service';
 import { ApplicationShell } from './shell/application-shell';
 import { Widget } from '@lumino/widgets';
 disableJSDOM();
 
 describe('PerspectiveService', () => {
-    let service: PerspectiveService;
+    let service: PerspectiveServiceImpl;
     let addWidgetStub: sinon.SinonStub;
     let activateWidgetStub: sinon.SinonStub;
     let getTabBarForStub: sinon.SinonStub;
@@ -42,7 +42,7 @@ describe('PerspectiveService', () => {
 
     beforeEach(() => {
         toTearDown = enableJSDOM();
-        service = new PerspectiveService();
+        service = new PerspectiveServiceImpl();
         testWidget = new Widget();
         testWidget.id = 'test-widget';
 
@@ -279,7 +279,7 @@ describe('PerspectiveService', () => {
         service.initialize();
 
         const perspectives = service.getRegisteredPerspectives();
-        const defaultPerspective = perspectives.find(p => p.id === PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        const defaultPerspective = perspectives.find(p => p.id === PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
         expect(defaultPerspective).to.not.be.undefined;
         expect(defaultPerspective!.label).to.equal('Default');
         expect(defaultPerspective!.viewPlacements.size).to.equal(0);
@@ -290,7 +290,7 @@ describe('PerspectiveService', () => {
 
         const active = service.getActivePerspective();
         expect(active).to.not.be.undefined;
-        expect(active!.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        expect(active!.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
     });
 
     it('should not re-apply when switching to the already-active perspective', async () => {
@@ -455,7 +455,7 @@ describe('PerspectiveService', () => {
         });
 
         // Start in default (set by initialize)
-        expect(service.getActivePerspective()?.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
 
         const defaultLayout = { mainPanel: { widgets: ['default-editor'] }, bottomPanel: {} };
         getLayoutDataStub.returns(defaultLayout);
@@ -472,8 +472,8 @@ describe('PerspectiveService', () => {
         setLayoutDataStub.resetHistory();
 
         // Switch back to default (saves ai-first layout, restores default layout)
-        await service.switchPerspective(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
-        expect(service.getActivePerspective()?.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        await service.switchPerspective(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
         expect(setLayoutDataStub.calledOnce).to.be.true;
         expect(setLayoutDataStub.calledWith(defaultLayout)).to.be.true;
 
@@ -893,11 +893,9 @@ describe('PerspectiveService', () => {
         expect(service.getActivePerspective()?.id).to.equal('perspC');
     });
 
-    // --- PerspectiveLayoutProvider interface tests ---
-
-    describe('PerspectiveLayoutProvider implementation', () => {
+    describe('Plumbing API (layout persistence)', () => {
         it('should return default perspective ID when none is set', () => {
-            expect(service.getActivePerspectiveId()).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+            expect(service.getActivePerspectiveId()).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
         });
 
         it('should return active perspective ID after switching', async () => {

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -36,7 +36,7 @@ describe('PerspectiveService', () => {
     let collapsePanelStub: sinon.SinonStub;
     let setStatusBarHiddenByPerspectiveStub: sinon.SinonStub;
     let setWidgetAreaResolverStub: sinon.SinonStub;
-    let mockLogger: { debug: sinon.SinonStub };
+    let mockLogger: { debug: sinon.SinonStub; warn: sinon.SinonStub };
     let testWidget: Widget;
     let toTearDown: () => void;
 
@@ -56,7 +56,7 @@ describe('PerspectiveService', () => {
         collapsePanelStub = sinon.stub().resolves();
         setStatusBarHiddenByPerspectiveStub = sinon.stub();
         setWidgetAreaResolverStub = sinon.stub();
-        mockLogger = { debug: sinon.stub() };
+        mockLogger = { debug: sinon.stub(), warn: sinon.stub() };
 
         const mockShell = {
             addWidget: addWidgetStub,
@@ -762,5 +762,212 @@ describe('PerspectiveService', () => {
 
         expect(callOrder).to.deep.equal(['activate-A', 'activate-B', 'activate-C']);
         expect(service.getActivePerspective()?.id).to.equal('perspC');
+    });
+
+    // --- onStop() no-op test ---
+
+    it('should not persist layouts on onStop (handled by ShellLayoutRestorer)', () => {
+        service.initialize();
+
+        getLayoutDataStub.returns({ mainPanel: { widgets: ['editor1'] }, bottomPanel: {} });
+
+        service.onStop!({} as never);
+    });
+
+    // --- onLayoutRestored() tests ---
+
+    it('should apply chrome options when onLayoutRestored is called with a registered perspective', () => {
+        service.registerPerspective({
+            id: 'chrome-persp',
+            label: 'Chrome Persp',
+            viewPlacements: new Map(),
+            chromeOptions: { hideStatusBar: true }
+        });
+        service.initialize();
+
+        service.onLayoutRestored('chrome-persp');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+    });
+
+    it('should not hide status bar when restored perspective has no chrome options', () => {
+        service.registerPerspective({
+            id: 'no-chrome-persp',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+        service.initialize();
+
+        service.onLayoutRestored('no-chrome-persp');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(false)).to.be.true;
+    });
+
+    it('should not apply chrome when onLayoutRestored is called with an unregistered perspective', () => {
+        service.initialize();
+
+        service.onLayoutRestored('non-existent');
+
+        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.false;
+    });
+
+    // --- Rejection resilience tests ---
+
+    it('should warn and continue when setLayoutData rejects during saved layout restore', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // Switch to A, then to B (saves A's layout)
+        await service.switchPerspective('perspA');
+        await service.switchPerspective('perspB');
+
+        // Make setLayoutData reject
+        setLayoutDataStub.rejects(new Error('layout error'));
+
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        // Switch back to A — should not throw
+        await service.switchPerspective('perspA');
+
+        expect(service.getActivePerspective()?.id).to.equal('perspA');
+        expect(eventSpy.calledOnce).to.be.true;
+        expect(eventSpy.calledWith('perspA')).to.be.true;
+        expect(mockLogger.warn.calledOnce).to.be.true;
+        expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to apply layout for perspective');
+    });
+
+    it('should warn and continue when collapsePanel rejects on first activation', async () => {
+        service.registerPerspective({
+            id: 'collapse-fail',
+            label: 'Collapse Fail',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left'] }
+        });
+
+        collapsePanelStub.rejects(new Error('collapse error'));
+
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        // Switch — should not throw
+        await service.switchPerspective('collapse-fail');
+
+        expect(service.getActivePerspective()?.id).to.equal('collapse-fail');
+        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.true;
+        expect(eventSpy.calledOnce).to.be.true;
+        expect(mockLogger.warn.calledOnce).to.be.true;
+        expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to apply layout for perspective');
+    });
+
+    it('should not drop queued switches when layout application fails', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspC',
+            label: 'C',
+            viewPlacements: new Map()
+        });
+
+        // Switch to A, then to B (saves A's layout)
+        await service.switchPerspective('perspA');
+        await service.switchPerspective('perspB');
+
+        // Make setLayoutData reject only on first call, then resolve
+        setLayoutDataStub.resetBehavior();
+        setLayoutDataStub.onFirstCall().rejects(new Error('layout error'));
+        setLayoutDataStub.onSecondCall().resolves();
+
+        // Queue: switch to A (will fail layout restore), then switch to C
+        const p1 = service.switchPerspective('perspA');
+        const p2 = service.switchPerspective('perspC');
+
+        await Promise.all([p1, p2]);
+
+        expect(service.getActivePerspective()?.id).to.equal('perspC');
+    });
+
+    // --- PerspectiveLayoutProvider interface tests ---
+
+    describe('PerspectiveLayoutProvider implementation', () => {
+        it('should return default perspective ID when none is set', () => {
+            expect(service.getActivePerspectiveId()).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        });
+
+        it('should return active perspective ID after switching', async () => {
+            service.registerPerspective({
+                id: 'test-persp',
+                label: 'Test',
+                viewPlacements: new Map()
+            });
+            await service.switchPerspective('test-persp');
+            expect(service.getActivePerspectiveId()).to.equal('test-persp');
+        });
+
+        it('should round-trip getSavedLayout/setSavedLayout', () => {
+            const layout = { mainPanel: { widgets: ['w1'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('persp-x', layout);
+
+            expect(service.getSavedLayout('persp-x')).to.equal(layout);
+        });
+
+        it('should return undefined for non-existent saved layout', () => {
+            expect(service.getSavedLayout('no-such-persp')).to.be.undefined;
+        });
+
+        it('should return correct saved perspective IDs', () => {
+            const layout1 = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            const layout2 = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('a', layout1);
+            service.setSavedLayout('b', layout2);
+
+            const ids = service.getSavedPerspectiveIds();
+            expect(ids).to.include('a');
+            expect(ids).to.include('b');
+            expect(ids).to.have.lengthOf(2);
+        });
+
+        it('should set active perspective ID only for registered perspectives', () => {
+            service.registerPerspective({
+                id: 'registered',
+                label: 'Registered',
+                viewPlacements: new Map()
+            });
+
+            service.setActivePerspectiveId('registered');
+            expect(service.getActivePerspectiveId()).to.equal('registered');
+
+            // Should ignore unregistered perspective IDs
+            service.setActivePerspectiveId('unregistered');
+            expect(service.getActivePerspectiveId()).to.equal('registered');
+        });
+
+        it('should clear all saved layouts', () => {
+            const layout = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('a', layout);
+            service.setSavedLayout('b', layout);
+
+            service.clearSavedLayouts();
+
+            expect(service.getSavedPerspectiveIds()).to.have.lengthOf(0);
+            expect(service.getSavedLayout('a')).to.be.undefined;
+            expect(service.getSavedLayout('b')).to.be.undefined;
+        });
     });
 });

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -764,16 +764,6 @@ describe('PerspectiveService', () => {
         expect(service.getActivePerspective()?.id).to.equal('perspC');
     });
 
-    // --- onStop() no-op test ---
-
-    it('should not persist layouts on onStop (handled by ShellLayoutRestorer)', () => {
-        service.initialize();
-
-        getLayoutDataStub.returns({ mainPanel: { widgets: ['editor1'] }, bottomPanel: {} });
-
-        service.onStop!({} as never);
-    });
-
     // --- onLayoutRestored() tests ---
 
     it('should apply chrome options when onLayoutRestored is called with a registered perspective', () => {
@@ -950,11 +940,10 @@ describe('PerspectiveService', () => {
                 viewPlacements: new Map()
             });
 
-            service.setActivePerspectiveId('registered');
+            expect(service.setActivePerspectiveId('registered')).to.be.true;
             expect(service.getActivePerspectiveId()).to.equal('registered');
 
-            // Should ignore unregistered perspective IDs
-            service.setActivePerspectiveId('unregistered');
+            expect(service.setActivePerspectiveId('unregistered')).to.be.false;
             expect(service.getActivePerspectiveId()).to.equal('registered');
         });
 

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -894,6 +894,10 @@ describe('PerspectiveService', () => {
     });
 
     describe('Plumbing API (layout persistence)', () => {
+        it('should expose defaultPerspectiveId matching the static constant', () => {
+            expect(service.defaultPerspectiveId).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        });
+
         it('should return default perspective ID when none is set', () => {
             expect(service.getActivePerspectiveId()).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
         });

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -83,45 +83,45 @@ export interface PerspectiveService {
 
     /**
      * Returns the IDs of all perspectives that have a saved (in-memory) layout snapshot.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
      */
     getSavedPerspectiveIds(): string[];
 
     /**
      * Returns the saved in-memory layout for a perspective, or `undefined` if none exists.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
      */
     getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
 
     /**
      * Stores an in-memory layout snapshot for a perspective.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
      */
     setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
 
     /**
      * Sets the active perspective ID (without triggering a switch).
      * Returns `true` if the ID corresponds to a registered perspective, `false` otherwise.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` during layout restore.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` during layout restore.
      */
     setActivePerspectiveId(id: string): boolean;
 
     /**
      * The ID of the built-in default perspective.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` for legacy migration.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for legacy migration.
      */
     readonly defaultPerspectiveId: string;
 
     /**
      * Clears all saved in-memory layout snapshots.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` during layout reset.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` during layout reset.
      */
     clearSavedLayouts(): void;
 
     /**
      * Called by `ShellLayoutRestorer` after restoring a persisted layout to apply chrome options
      * (e.g., status bar visibility) for the given perspective.
-     * @internal Plumbing API — used by `ShellLayoutRestorer` after layout restore.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` after layout restore.
      */
     onLayoutRestored(activePerspectiveId: string): void;
 }

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -26,7 +26,6 @@ import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
 import { nls } from '../common/nls';
 import { DisposableCollection } from '../common/disposable';
 import { CommonCommands } from './common-commands';
-import { PerspectiveLayoutProvider } from './shell/shell-layout-restorer';
 
 export interface PerspectiveChromeOptions {
     /** Hide the status bar. Default: false. */
@@ -48,13 +47,86 @@ export interface PerspectiveDescriptor {
     onDeactivate?(shell: ApplicationShell): void;
 }
 
+export const PerspectiveService = Symbol('PerspectiveService');
+export interface PerspectiveService {
+    // --- High-level API (for general consumers) ---
+
+    /** Event fired whenever the active perspective changes. The payload is the new perspective ID. */
+    readonly onDidChangePerspective: Event<string>;
+
+    /**
+     * Registers a new perspective descriptor.
+     * Contributions should call this from their `PerspectiveContribution.registerPerspectives` callback.
+     */
+    registerPerspective(descriptor: PerspectiveDescriptor): void;
+
+    /**
+     * Switches the workbench to the given perspective.
+     * Saves the current perspective's layout, then restores the target perspective's layout
+     * (or applies its `viewPlacements` on first activation). Concurrent calls are serialized.
+     */
+    switchPerspective(id: string): Promise<void>;
+
+    /** Returns the descriptor of the currently active perspective, or `undefined` if none. */
+    getActivePerspective(): PerspectiveDescriptor | undefined;
+
+    /** Returns the target shell area for a widget in the active perspective, or `undefined` if unmapped. */
+    getAreaForView(viewId: string): ApplicationShell.Area | undefined;
+
+    /** Returns all registered perspective descriptors. */
+    getRegisteredPerspectives(): PerspectiveDescriptor[];
+
+    /** Returns the ID of the currently active perspective. A convenient alternative to `getActivePerspective()?.id` that always returns a string. */
+    getActivePerspectiveId(): string;
+
+    // --- Plumbing API (for layout persistence infrastructure, not general consumers) ---
+
+    /**
+     * Returns the IDs of all perspectives that have a saved (in-memory) layout snapshot.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     */
+    getSavedPerspectiveIds(): string[];
+
+    /**
+     * Returns the saved in-memory layout for a perspective, or `undefined` if none exists.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     */
+    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
+
+    /**
+     * Stores an in-memory layout snapshot for a perspective.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` for layout persistence.
+     */
+    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
+
+    /**
+     * Sets the active perspective ID (without triggering a switch).
+     * Returns `true` if the ID corresponds to a registered perspective, `false` otherwise.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` during layout restore.
+     */
+    setActivePerspectiveId(id: string): boolean;
+
+    /**
+     * Clears all saved in-memory layout snapshots.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` during layout reset.
+     */
+    clearSavedLayouts(): void;
+
+    /**
+     * Called by `ShellLayoutRestorer` after restoring a persisted layout to apply chrome options
+     * (e.g., status bar visibility) for the given perspective.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` after layout restore.
+     */
+    onLayoutRestored(activePerspectiveId: string): void;
+}
+
 export const PerspectiveContribution = Symbol('PerspectiveContribution');
 export interface PerspectiveContribution {
     registerPerspectives(service: PerspectiveService): void;
 }
 
 @injectable()
-export class PerspectiveService implements FrontendApplicationContribution, CommandContribution, PerspectiveLayoutProvider {
+export class PerspectiveServiceImpl implements FrontendApplicationContribution, CommandContribution, PerspectiveService {
 
     static readonly SWITCH_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
         id: 'perspective.switch',
@@ -98,11 +170,11 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
 
     initialize(): void {
         this.registerPerspective({
-            id: PerspectiveService.DEFAULT_PERSPECTIVE_ID,
+            id: PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID,
             label: nls.localizeByDefault('Default'),
             viewPlacements: new Map()
         });
-        this.activePerspectiveId = PerspectiveService.DEFAULT_PERSPECTIVE_ID;
+        this.activePerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
 
         this.shell.setWidgetAreaResolver((widgetId, _requestedArea) =>
             this.getAreaForView(widgetId)
@@ -226,10 +298,8 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
         return Array.from(this.perspectives.values());
     }
 
-    // --- PerspectiveLayoutProvider implementation ---
-
     getActivePerspectiveId(): string {
-        return this.activePerspectiveId ?? PerspectiveService.DEFAULT_PERSPECTIVE_ID;
+        return this.activePerspectiveId ?? PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
     }
 
     getSavedPerspectiveIds(): string[] {
@@ -257,7 +327,7 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
     }
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(PerspectiveService.SWITCH_PERSPECTIVE_COMMAND, {
+        commands.registerCommand(PerspectiveServiceImpl.SWITCH_PERSPECTIVE_COMMAND, {
             execute: () => this.showPerspectivePicker(),
             isEnabled: () => this.perspectives.size > 0
         });

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -107,6 +107,12 @@ export interface PerspectiveService {
     setActivePerspectiveId(id: string): boolean;
 
     /**
+     * The ID of the built-in default perspective.
+     * @internal Plumbing API — used by `ShellLayoutRestorer` for legacy migration.
+     */
+    readonly defaultPerspectiveId: string;
+
+    /**
      * Clears all saved in-memory layout snapshots.
      * @internal Plumbing API — used by `ShellLayoutRestorer` during layout reset.
      */
@@ -150,6 +156,8 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
     protected readonly logger: ILogger;
 
     static readonly DEFAULT_PERSPECTIVE_ID = 'default';
+
+    readonly defaultPerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
 
     protected readonly perspectives = new Map<string, PerspectiveDescriptor>();
     protected activePerspectiveId: string | undefined;

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -244,10 +244,12 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
         this.savedLayouts.set(perspectiveId, layout);
     }
 
-    setActivePerspectiveId(id: string): void {
+    setActivePerspectiveId(id: string): boolean {
         if (this.perspectives.has(id)) {
             this.activePerspectiveId = id;
+            return true;
         }
+        return false;
     }
 
     clearSavedLayouts(): void {

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -26,6 +26,7 @@ import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
 import { nls } from '../common/nls';
 import { DisposableCollection } from '../common/disposable';
 import { CommonCommands } from './common-commands';
+import { PerspectiveLayoutProvider } from './shell/shell-layout-restorer';
 
 export interface PerspectiveChromeOptions {
     /** Hide the status bar. Default: false. */
@@ -53,7 +54,7 @@ export interface PerspectiveContribution {
 }
 
 @injectable()
-export class PerspectiveService implements FrontendApplicationContribution, CommandContribution {
+export class PerspectiveService implements FrontendApplicationContribution, CommandContribution, PerspectiveLayoutProvider {
 
     static readonly SWITCH_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
         id: 'perspective.switch',
@@ -87,6 +88,13 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
 
     protected readonly toDispose = new DisposableCollection();
     protected switchInProgress: Promise<void> | undefined;
+
+    onLayoutRestored(activePerspectiveId: string): void {
+        const descriptor = this.perspectives.get(activePerspectiveId);
+        if (descriptor) {
+            this.applyChrome(descriptor);
+        }
+    }
 
     initialize(): void {
         this.registerPerspective({
@@ -147,39 +155,43 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
 
         this.activePerspectiveId = id;
 
-        const savedLayout = this.savedLayouts.get(id);
-        if (savedLayout) {
-            await this.shell.setLayoutData(savedLayout);
-        } else {
-            for (const [viewId, area] of descriptor.viewPlacements) {
-                try {
-                    const widget = await this.widgetManager.getOrCreateWidget(viewId);
-                    const currentTabBar = this.shell.getTabBarFor(widget);
-                    if (currentTabBar) {
-                        const currentArea = this.shell.getAreaFor(widget);
-                        if (currentArea === area) {
-                            continue;
+        try {
+            const savedLayout = this.savedLayouts.get(id);
+            if (savedLayout) {
+                await this.shell.setLayoutData(savedLayout);
+            } else {
+                for (const [viewId, area] of descriptor.viewPlacements) {
+                    try {
+                        const widget = await this.widgetManager.getOrCreateWidget(viewId);
+                        const currentTabBar = this.shell.getTabBarFor(widget);
+                        if (currentTabBar) {
+                            const currentArea = this.shell.getAreaFor(widget);
+                            if (currentArea === area) {
+                                continue;
+                            }
                         }
+                        await this.shell.addWidget(widget, { area });
+                    } catch (error) {
+                        this.logger.debug('Failed to create or place widget for perspective', error);
                     }
-                    await this.shell.addWidget(widget, { area });
-                } catch (error) {
-                    this.logger.debug('Failed to create or place widget for perspective', error);
                 }
-            }
 
-            for (const [viewId] of descriptor.viewPlacements) {
-                try {
-                    await this.shell.activateWidget(viewId);
-                } catch (error) {
-                    this.logger.debug('Failed to activate widget for perspective', error);
+                for (const [viewId] of descriptor.viewPlacements) {
+                    try {
+                        await this.shell.activateWidget(viewId);
+                    } catch (error) {
+                        this.logger.debug('Failed to activate widget for perspective', error);
+                    }
                 }
-            }
 
-            if (descriptor.chromeOptions?.collapseAreas) {
-                for (const area of descriptor.chromeOptions.collapseAreas) {
-                    await this.shell.collapsePanel(area);
+                if (descriptor.chromeOptions?.collapseAreas) {
+                    for (const area of descriptor.chromeOptions.collapseAreas) {
+                        await this.shell.collapsePanel(area);
+                    }
                 }
             }
+        } catch (error) {
+            this.logger.warn('Failed to apply layout for perspective', error);
         }
 
         if (descriptor.onActivate) {
@@ -214,6 +226,34 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
         return Array.from(this.perspectives.values());
     }
 
+    // --- PerspectiveLayoutProvider implementation ---
+
+    getActivePerspectiveId(): string {
+        return this.activePerspectiveId ?? PerspectiveService.DEFAULT_PERSPECTIVE_ID;
+    }
+
+    getSavedPerspectiveIds(): string[] {
+        return Array.from(this.savedLayouts.keys());
+    }
+
+    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined {
+        return this.savedLayouts.get(perspectiveId);
+    }
+
+    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void {
+        this.savedLayouts.set(perspectiveId, layout);
+    }
+
+    setActivePerspectiveId(id: string): void {
+        if (this.perspectives.has(id)) {
+            this.activePerspectiveId = id;
+        }
+    }
+
+    clearSavedLayouts(): void {
+        this.savedLayouts.clear();
+    }
+
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(PerspectiveService.SWITCH_PERSPECTIVE_COMMAND, {
             execute: () => this.showPerspectivePicker(),
@@ -241,3 +281,4 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
         }
     }
 }
+

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -423,6 +423,25 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(legacyClear).to.not.be.undefined;
         });
 
+        it('should preserve legacy key when inflate fails', async () => {
+
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves('not-valid-json{');
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+            // Legacy key should NOT be cleared
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.be.undefined;
+            // No layout should have been saved
+            expect(mockProvider.setSavedLayout.called).to.be.false;
+            // Should warn about the failure
+            expect(mockLogger.warn.called).to.be.true;
+        });
+
         it('should apply migrated legacy layout to shell', async () => {
 
             const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy-w'] }, bottomPanel: {} });

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -1,0 +1,498 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '../test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import {
+    ShellLayoutRestorer,
+    PersistedPerspectiveData,
+    PERSPECTIVE_LAYOUTS_STORAGE_KEY
+} from './shell-layout-restorer';
+import { ApplicationShell } from './application-shell';
+disableJSDOM();
+
+describe('ShellLayoutRestorer - Perspective Support', () => {
+    let restorer: ShellLayoutRestorer;
+    let mockStorageService: { setData: sinon.SinonStub; getData: sinon.SinonStub };
+    let mockLogger: { info: sinon.SinonStub; error: sinon.SinonStub; warn: sinon.SinonStub };
+    let mockWidgetManager: { getDescription: sinon.SinonStub };
+    let mockShell: {
+        getLayoutData: sinon.SinonStub;
+        setLayoutData: sinon.SinonStub;
+    };
+    let mockApp: { shell: typeof mockShell };
+    let mockProvider: {
+        getActivePerspectiveId: sinon.SinonStub;
+        getSavedPerspectiveIds: sinon.SinonStub;
+        getSavedLayout: sinon.SinonStub;
+        setSavedLayout: sinon.SinonStub;
+        setActivePerspectiveId: sinon.SinonStub;
+        clearSavedLayouts: sinon.SinonStub;
+        onLayoutRestored: sinon.SinonStub;
+    };
+    let mockTransformations: { getContributions: sinon.SinonStub };
+    let mockMigrations: { getContributions: sinon.SinonStub };
+    let mockWindowService: { isSafeToShutDown: sinon.SinonStub; reload: sinon.SinonStub };
+    let mockThemeService: { reset: sinon.SinonStub };
+    let toTearDown: () => void;
+
+    beforeEach(() => {
+        toTearDown = enableJSDOM();
+
+        mockStorageService = {
+            setData: sinon.stub().resolves(),
+            getData: sinon.stub().resolves(undefined)
+        };
+        mockLogger = {
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub()
+        };
+        mockWidgetManager = {
+            getDescription: sinon.stub().returns(undefined)
+        };
+        mockShell = {
+            getLayoutData: sinon.stub().returns({ version: 999, mainPanel: {}, bottomPanel: {} }),
+            setLayoutData: sinon.stub().resolves()
+        };
+        mockApp = { shell: mockShell };
+        mockProvider = {
+            getActivePerspectiveId: sinon.stub().returns('default'),
+            getSavedPerspectiveIds: sinon.stub().returns([]),
+            getSavedLayout: sinon.stub().returns(undefined),
+            setSavedLayout: sinon.stub(),
+            setActivePerspectiveId: sinon.stub(),
+            clearSavedLayouts: sinon.stub(),
+            onLayoutRestored: sinon.stub()
+        };
+        mockTransformations = {
+            getContributions: sinon.stub().returns([])
+        };
+        mockMigrations = {
+            getContributions: sinon.stub().returns([])
+        };
+        mockWindowService = {
+            isSafeToShutDown: sinon.stub().resolves(true),
+            reload: sinon.stub()
+        };
+        mockThemeService = {
+            reset: sinon.stub()
+        };
+
+        restorer = new ShellLayoutRestorer(
+            mockWidgetManager as never,
+            mockLogger as never,
+            mockStorageService as never
+        );
+
+        (restorer as unknown as Record<string, unknown>)['perspectiveProvider'] = mockProvider;
+        (restorer as unknown as Record<string, unknown>)['transformations'] = mockTransformations;
+        (restorer as unknown as Record<string, unknown>)['migrations'] = mockMigrations;
+        (restorer as unknown as Record<string, unknown>)['windowService'] = mockWindowService;
+        (restorer as unknown as Record<string, unknown>)['themeService'] = mockThemeService;
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        toTearDown();
+    });
+
+    describe('storePerspectiveLayouts', () => {
+        it('should read current shell layout as the active perspective layout', () => {
+
+            mockProvider.getActivePerspectiveId.returns('persp-a');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+            const currentLayout = { version: 999, mainPanel: { items: ['editor1'] }, bottomPanel: {} };
+            mockShell.getLayoutData.returns(currentLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(data.activePerspectiveId).to.equal('persp-a');
+            expect(data.layouts['persp-a']).to.be.a('string');
+            // Verify it contains the current shell layout content
+            const parsed = JSON.parse(data.layouts['persp-a']);
+            expect(parsed.mainPanel.items).to.deep.equal(['editor1']);
+        });
+
+        it('should deflate all inactive perspective layouts from provider', () => {
+
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'inactive1', 'inactive2']);
+            const inactiveLayout1 = { version: 999, mainPanel: { items: ['w1'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            const inactiveLayout2 = { version: 999, mainPanel: { items: ['w2'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('inactive1').returns(inactiveLayout1);
+            mockProvider.getSavedLayout.withArgs('inactive2').returns(inactiveLayout2);
+            mockProvider.getSavedLayout.withArgs('active').returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(Object.keys(data.layouts)).to.have.lengthOf(3);
+            expect(data.layouts).to.have.property('active');
+            expect(data.layouts).to.have.property('inactive1');
+            expect(data.layouts).to.have.property('inactive2');
+        });
+
+        it('should use shell layout for active perspective, not provider', () => {
+
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active']);
+            // Provider has stale data for the active perspective
+            const staleLayout = { version: 999, mainPanel: { items: ['stale'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('active').returns(staleLayout);
+            // Shell has the current data
+            const currentLayout = { version: 999, mainPanel: { items: ['current'] }, bottomPanel: {} };
+            mockShell.getLayoutData.returns(currentLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            const parsed = JSON.parse(data.layouts['active']);
+            // Should use shell data, not provider data
+            expect(parsed.mainPanel.items).to.deep.equal(['current']);
+        });
+
+        it('should not write to legacy key', () => {
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+
+            restorer.storeLayout(mockApp as never);
+
+            // Should only write to perspective key, not legacy key
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            expect(mockStorageService.setData.firstCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+        });
+    });
+
+    describe('restorePerspectiveLayouts', () => {
+        it('should inflate all layouts and push to provider', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'persp-a',
+                layouts: {
+                    'persp-a': JSON.stringify({ version: 999, mainPanel: { items: ['a'] }, bottomPanel: {} }),
+                    'persp-b': JSON.stringify({ version: 999, mainPanel: { items: ['b'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            // Return the inflated layout for the active persp when asked
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                if (id === 'persp-a') {
+                    // After setSavedLayout is called, return the layout
+                    const call = mockProvider.setSavedLayout.getCalls().find(
+                        (c: sinon.SinonSpyCall) => c.args[0] === 'persp-a'
+                    );
+                    return call?.args[1];
+                }
+                return undefined;
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            expect(mockProvider.setSavedLayout.callCount).to.equal(2);
+            // Verify persp-a was set
+            const setACall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'persp-a'
+            );
+            expect(setACall).to.not.be.undefined;
+            // Verify persp-b was set
+            const setBCall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'persp-b'
+            );
+            expect(setBCall).to.not.be.undefined;
+        });
+
+        it('should set active perspective ID on provider', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'my-persp',
+                layouts: {
+                    'my-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.setActivePerspectiveId.calledWith('my-persp')).to.be.true;
+        });
+
+        it('should apply the active layout to the shell', async () => {
+
+            const layoutData = { version: 999, mainPanel: { items: ['active-item'] }, bottomPanel: {} };
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'active',
+                layouts: {
+                    'active': JSON.stringify(layoutData)
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockShell.setLayoutData.calledOnce).to.be.true;
+            const applied = mockShell.setLayoutData.firstCall.args[0];
+            expect(applied.mainPanel.items).to.deep.equal(['active-item']);
+        });
+
+        it('should apply transformations to the active layout', async () => {
+
+            const transformer = {
+                transformLayoutOnRestore: sinon.stub()
+            };
+            mockTransformations.getContributions.returns([transformer]);
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'active',
+                layouts: {
+                    'active': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(transformer.transformLayoutOnRestore.calledOnce).to.be.true;
+        });
+
+        it('should return false when no perspective data and no legacy data exists', async () => {
+
+            mockStorageService.getData.resolves(undefined);
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+        });
+
+        it('should warn when a perspective layout fails to inflate', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'good',
+                layouts: {
+                    'good': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'bad': 'invalid-json{'
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            // 'good' should be inflated successfully
+            const goodCall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'good'
+            );
+            expect(goodCall).to.not.be.undefined;
+
+            // Should warn about 'bad'
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('bad')
+            );
+            expect(warnCall).to.not.be.undefined;
+        });
+    });
+
+    describe('legacy migration', () => {
+        it('should fall back to legacy key when perspective-layouts is absent', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should push layout as 'default' perspective
+            expect(mockProvider.setSavedLayout.calledOnce).to.be.true;
+            expect(mockProvider.setSavedLayout.firstCall.args[0]).to.equal('default');
+            // Should set active to 'default'
+            expect(mockProvider.setActivePerspectiveId.calledWith('default')).to.be.true;
+            // Should delete legacy key after migration
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.not.be.undefined;
+        });
+
+        it('should delete legacy key after successful migration', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.not.be.undefined;
+        });
+
+        it('should apply migrated legacy layout to shell', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy-w'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockShell.setLayoutData.calledOnce).to.be.true;
+        });
+    });
+
+    describe('resetLayout', () => {
+        it('should clear layouts and legacy layout keys', async () => {
+
+            // Access private method
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            const setDataCalls = mockStorageService.setData.getCalls();
+            const layoutClear = setDataCalls.find((c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined);
+            const perspClear = setDataCalls.find((c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] === undefined);
+
+            expect(layoutClear).to.not.be.undefined;
+            expect(perspClear).to.not.be.undefined;
+        });
+
+        it('should call provider.clearSavedLayouts', async () => {
+
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            expect(mockProvider.clearSavedLayouts.calledOnce).to.be.true;
+        });
+
+        it('should reload the window after reset', async () => {
+
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            expect(mockWindowService.reload.calledOnce).to.be.true;
+        });
+    });
+
+    describe('onLayoutRestored callback', () => {
+        it('should call onLayoutRestored on provider after successful restore', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'my-persp',
+                layouts: {
+                    'my-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+            expect(mockProvider.onLayoutRestored.calledWith('my-persp')).to.be.true;
+        });
+
+        it('should not call onLayoutRestored when no layout is restored', async () => {
+
+            mockStorageService.getData.resolves(undefined);
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.onLayoutRestored.called).to.be.false;
+        });
+
+        it('should call onLayoutRestored after layout is applied to shell', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'active',
+                layouts: {
+                    'active': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            // onLayoutRestored should be called after setLayoutData
+            expect(mockShell.setLayoutData.calledBefore(mockProvider.onLayoutRestored)).to.be.true;
+        });
+    });
+});

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -101,7 +101,7 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             mockStorageService as never
         );
 
-        (restorer as unknown as Record<string, unknown>)['perspectiveProvider'] = mockProvider;
+        (restorer as unknown as Record<string, unknown>)['perspectiveService'] = mockProvider;
         (restorer as unknown as Record<string, unknown>)['transformations'] = mockTransformations;
         (restorer as unknown as Record<string, unknown>)['migrations'] = mockMigrations;
         (restorer as unknown as Record<string, unknown>)['windowService'] = mockWindowService;

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -496,16 +496,19 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(mockLogger.warn.called).to.be.true;
         });
 
-        it('should clear storage key when setData throws', () => {
+        it('should clear storage key when setData rejects', async () => {
             mockProvider.getActivePerspectiveId.returns('default');
             mockProvider.getSavedPerspectiveIds.returns([]);
 
-            mockStorageService.setData.onFirstCall().throws(new Error('storage error'));
-            mockStorageService.setData.onSecondCall().returns(undefined);
+            mockStorageService.setData.onFirstCall().rejects(new Error('storage error'));
+            mockStorageService.setData.onSecondCall().resolves();
 
             restorer.storeLayout(mockApp as never);
 
-            // First call throws, second call clears the key
+            // Allow the .catch() handler to execute
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            // First call rejects, second call clears the key
             expect(mockStorageService.setData.calledTwice).to.be.true;
             expect(mockStorageService.setData.secondCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
             expect(mockStorageService.setData.secondCall.args[1]).to.be.undefined;

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -77,7 +77,7 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             getSavedPerspectiveIds: sinon.stub().returns([]),
             getSavedLayout: sinon.stub().returns(undefined),
             setSavedLayout: sinon.stub(),
-            setActivePerspectiveId: sinon.stub(),
+            setActivePerspectiveId: sinon.stub().returns(true),
             clearSavedLayouts: sinon.stub(),
             onLayoutRestored: sinon.stub()
         };
@@ -270,7 +270,7 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(applied.mainPanel.items).to.deep.equal(['active-item']);
         });
 
-        it('should apply transformations to the active layout', async () => {
+        it('should apply transformations to all inflated layouts, not just the active one', async () => {
 
             const transformer = {
                 transformLayoutOnRestore: sinon.stub()
@@ -278,13 +278,13 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             mockTransformations.getContributions.returns([transformer]);
 
             const persisted: PersistedPerspectiveData = {
-                activePerspectiveId: 'active',
+                activePerspectiveId: 'persp-a',
                 layouts: {
-                    'active': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                    'persp-a': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'persp-b': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
                 }
             };
             mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
-
             mockProvider.getSavedLayout.callsFake((id: string) => {
                 const call = mockProvider.setSavedLayout.getCalls().find(
                     (c: sinon.SinonSpyCall) => c.args[0] === id
@@ -294,7 +294,37 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
 
             await restorer.restoreLayout(mockApp as never);
 
-            expect(transformer.transformLayoutOnRestore.calledOnce).to.be.true;
+            // Transformer should be called for both layouts
+            expect(transformer.transformLayoutOnRestore.callCount).to.equal(2);
+        });
+
+        it('should fall back to provider active ID when persisted ID is not registered', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'removed-persp',
+                layouts: {
+                    'removed-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'default': JSON.stringify({ version: 999, mainPanel: { items: ['default-w'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+            mockProvider.setActivePerspectiveId.returns(false);
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should apply 'default' layout to shell, not 'removed-persp'
+            const applied = mockShell.setLayoutData.firstCall.args[0];
+            expect(applied.mainPanel.items).to.deep.equal(['default-w']);
+            // onLayoutRestored should be called with 'default'
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
         });
 
         it('should return false when no perspective data and no legacy data exists', async () => {

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -45,6 +45,7 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
         setActivePerspectiveId: sinon.SinonStub;
         clearSavedLayouts: sinon.SinonStub;
         onLayoutRestored: sinon.SinonStub;
+        defaultPerspectiveId: string;
     };
     let mockTransformations: { getContributions: sinon.SinonStub };
     let mockMigrations: { getContributions: sinon.SinonStub };
@@ -79,7 +80,8 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             setSavedLayout: sinon.stub(),
             setActivePerspectiveId: sinon.stub().returns(true),
             clearSavedLayouts: sinon.stub(),
-            onLayoutRestored: sinon.stub()
+            onLayoutRestored: sinon.stub(),
+            defaultPerspectiveId: 'default'
         };
         mockTransformations = {
             getContributions: sinon.stub().returns([])
@@ -440,6 +442,142 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
         });
     });
 
+    describe('storePerspectiveLayouts - error isolation', () => {
+        it('should persist other perspectives when one inactive perspective deflate fails', () => {
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'good', 'bad']);
+
+            const goodLayout = { version: 999, mainPanel: { items: ['good'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            // Create a layout with a circular reference that will cause JSON.stringify to throw
+            const badLayout: Record<string, unknown> = { version: 999, mainPanel: {}, bottomPanel: {} };
+            badLayout['self'] = badLayout;
+
+            mockProvider.getSavedLayout.withArgs('good').returns(goodLayout);
+            mockProvider.getSavedLayout.withArgs('bad').returns(badLayout);
+            mockProvider.getSavedLayout.withArgs('active').returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            // Should still persist — 'active' and 'good' should be in layouts
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(data.layouts).to.have.property('active');
+            expect(data.layouts).to.have.property('good');
+            expect(data.layouts).to.not.have.property('bad');
+
+            // Should warn about 'bad'
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('bad')
+            );
+            expect(warnCall).to.not.be.undefined;
+        });
+
+        it('should persist inactive perspectives when active perspective deflate fails', () => {
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'inactive']);
+
+            // Make the shell return a circular structure for the active perspective
+            const circularLayout: Record<string, unknown> = { version: 999, mainPanel: {}, bottomPanel: {} };
+            circularLayout['self'] = circularLayout;
+            mockShell.getLayoutData.returns(circularLayout);
+
+            const inactiveLayout = { version: 999, mainPanel: { items: ['inactive'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('inactive').returns(inactiveLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(data.layouts).to.not.have.property('active');
+            expect(data.layouts).to.have.property('inactive');
+
+            expect(mockLogger.warn.called).to.be.true;
+        });
+
+        it('should clear storage key when setData throws', () => {
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+
+            mockStorageService.setData.onFirstCall().throws(new Error('storage error'));
+            mockStorageService.setData.onSecondCall().returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            // First call throws, second call clears the key
+            expect(mockStorageService.setData.calledTwice).to.be.true;
+            expect(mockStorageService.setData.secondCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(mockStorageService.setData.secondCall.args[1]).to.be.undefined;
+
+            expect(mockLogger.error.called).to.be.true;
+        });
+    });
+
+    describe('restorePerspectiveLayouts - desync fallback', () => {
+        it('should fall back to default perspective when active perspective has no saved layout', async () => {
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'custom',
+                layouts: {
+                    'default': JSON.stringify({ version: 999, mainPanel: { items: ['default-w'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            // 'custom' is a registered perspective, but has no layout entry
+            mockProvider.setActivePerspectiveId.returns(true);
+
+            // Track calls to setActivePerspectiveId to simulate state changes
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should have fallen back to default
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('custom')
+            );
+            expect(warnCall).to.not.be.undefined;
+            // Should have called onLayoutRestored with default
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
+        });
+
+        it('should call onLayoutRestored even when falling through to no layout', async () => {
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'custom',
+                layouts: {}
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+            mockProvider.getSavedLayout.returns(undefined);
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+            // onLayoutRestored should still be called
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+        });
+    });
+
     describe('resetLayout', () => {
         it('should clear layouts and legacy layout keys', async () => {
 
@@ -480,6 +618,13 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             };
             mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
 
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+
             mockProvider.getSavedLayout.callsFake((id: string) => {
                 const call = mockProvider.setSavedLayout.getCalls().find(
                     (c: sinon.SinonSpyCall) => c.args[0] === id
@@ -493,13 +638,14 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(mockProvider.onLayoutRestored.calledWith('my-persp')).to.be.true;
         });
 
-        it('should not call onLayoutRestored when no layout is restored', async () => {
+        it('should call onLayoutRestored even when no layout is restored', async () => {
 
             mockStorageService.getData.resolves(undefined);
 
             await restorer.restoreLayout(mockApp as never);
 
-            expect(mockProvider.onLayoutRestored.called).to.be.false;
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
         });
 
         it('should call onLayoutRestored after layout is applied to shell', async () => {
@@ -511,6 +657,13 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
                 }
             };
             mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
 
             mockProvider.getSavedLayout.callsFake((id: string) => {
                 const call = mockProvider.setSavedLayout.getCalls().find(

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -137,7 +137,7 @@ export interface PerspectiveLayoutProvider {
     getSavedPerspectiveIds(): string[];
     getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
     setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
-    setActivePerspectiveId(id: string): void;
+    setActivePerspectiveId(id: string): boolean;
     clearSavedLayouts(): void;
     onLayoutRestored(activePerspectiveId: string): void;
 }
@@ -234,10 +234,12 @@ export class ShellLayoutRestorer implements CommandContribution {
 
         if (persisted) {
             activeId = persisted.activePerspectiveId;
-            // Inflate all perspective layouts and push to provider
+            // Inflate all perspective layouts, apply transforms, and push to provider
             for (const [perspId, deflated] of Object.entries(persisted.layouts)) {
                 try {
                     const layout = await this.inflate(deflated);
+                    this.transformations.getContributions()
+                        .forEach(t => t.transformLayoutOnRestore(layout));
                     this.perspectiveProvider.setSavedLayout(perspId, layout);
                 } catch (error) {
                     this.logger.warn(`Could not inflate layout for perspective '${perspId}'`, error);
@@ -249,6 +251,8 @@ export class ShellLayoutRestorer implements CommandContribution {
             if (legacyData) {
                 try {
                     const layout = await this.inflate(legacyData);
+                    this.transformations.getContributions()
+                        .forEach(t => t.transformLayoutOnRestore(layout));
                     this.perspectiveProvider.setSavedLayout('default', layout);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
@@ -259,20 +263,18 @@ export class ShellLayoutRestorer implements CommandContribution {
         }
 
         if (activeId) {
-            this.perspectiveProvider.setActivePerspectiveId(activeId);
+            const accepted = this.perspectiveProvider.setActivePerspectiveId(activeId);
+            if (!accepted) {
+                activeId = this.perspectiveProvider.getActivePerspectiveId();
+            }
         }
 
         // Apply the active perspective's layout to the shell
-        const activeLayout = this.perspectiveProvider.getSavedLayout(
-            activeId ?? this.perspectiveProvider.getActivePerspectiveId()
-        );
+        const effectiveId = activeId ?? this.perspectiveProvider.getActivePerspectiveId();
+        const activeLayout = this.perspectiveProvider.getSavedLayout(effectiveId);
         if (activeLayout) {
-            this.transformations.getContributions()
-                .forEach(t => t.transformLayoutOnRestore(activeLayout));
             await app.shell.setLayoutData(activeLayout);
-            this.perspectiveProvider.onLayoutRestored(
-                activeId ?? this.perspectiveProvider.getActivePerspectiveId()
-            );
+            this.perspectiveProvider.onLayoutRestored(effectiveId);
             this.logger.info('<<< The layout has been successfully restored.');
             return true;
         }
@@ -292,7 +294,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     /**
      * Turns the layout data to a string representation.
      */
-    deflate(data: object): string {
+    protected deflate(data: object): string {
         return JSON.stringify(data, (property: string, value) => {
             if (this.isWidgetProperty(property)) {
                 const description = this.convertToDescription(value as Widget);
@@ -332,7 +334,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     /**
      * Creates the layout data from its string representation.
      */
-    async inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
+    protected async inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
         const parseContext = new ShellLayoutRestorer.ParseContext();
         const layout = this.parse<ApplicationShell.LayoutData>(layoutData, parseContext);
 

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -255,11 +255,11 @@ export class ShellLayoutRestorer implements CommandContribution {
                     this.transformations.getContributions()
                         .forEach(t => t.transformLayoutOnRestore(layout));
                     this.perspectiveService.setSavedLayout(this.perspectiveService.defaultPerspectiveId, layout);
+                    activeId = this.perspectiveService.defaultPerspectiveId;
+                    this.storageService.setData(this.legacyStorageKey, undefined);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
                 }
-                activeId = this.perspectiveService.defaultPerspectiveId;
-                this.storageService.setData(this.legacyStorageKey, undefined);
             }
         }
 

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -28,6 +28,7 @@ import { CommonCommands } from '../common-commands';
 import { WindowService } from '../window/window-service';
 import { StopReason } from '../../common/frontend-application-state';
 import { isFunction, isObject, MaybePromise } from '../../common';
+import { PerspectiveService } from '../perspective-service';
 
 /**
  * A contract for widgets that want to store and restore their inner state, between sessions.
@@ -131,17 +132,6 @@ export interface PersistedPerspectiveData {
     layouts: Record<string, string>;
 }
 
-export const PerspectiveLayoutProvider = Symbol('PerspectiveLayoutProvider');
-export interface PerspectiveLayoutProvider {
-    getActivePerspectiveId(): string;
-    getSavedPerspectiveIds(): string[];
-    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
-    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
-    setActivePerspectiveId(id: string): boolean;
-    clearSavedLayouts(): void;
-    onLayoutRestored(activePerspectiveId: string): void;
-}
-
 export const RESET_LAYOUT = Command.toLocalizedCommand({
     id: 'reset.layout',
     category: CommonCommands.VIEW_CATEGORY,
@@ -159,8 +149,8 @@ export class ShellLayoutRestorer implements CommandContribution {
     @inject(WindowService) protected readonly windowService: WindowService;
     @inject(ThemeService) protected readonly themeService: ThemeService;
 
-    @inject(PerspectiveLayoutProvider)
-    protected readonly perspectiveProvider: PerspectiveLayoutProvider;
+    @inject(PerspectiveService)
+    protected readonly perspectiveService: PerspectiveService;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -178,7 +168,7 @@ export class ShellLayoutRestorer implements CommandContribution {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
             this.storageService.setData(this.legacyStorageKey, undefined);
-            this.perspectiveProvider.clearSavedLayouts();
+            this.perspectiveService.clearSavedLayouts();
             this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
             this.themeService.reset();
             this.logger.info('<<< The layout has been successfully reset.');
@@ -199,7 +189,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     }
 
     protected storePerspectiveLayouts(app: FrontendApplication): void {
-        const provider = this.perspectiveProvider;
+        const provider = this.perspectiveService;
         const activeId = provider.getActivePerspectiveId();
         const layouts: Record<string, string> = {};
 
@@ -240,7 +230,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                     const layout = await this.inflate(deflated);
                     this.transformations.getContributions()
                         .forEach(t => t.transformLayoutOnRestore(layout));
-                    this.perspectiveProvider.setSavedLayout(perspId, layout);
+                    this.perspectiveService.setSavedLayout(perspId, layout);
                 } catch (error) {
                     this.logger.warn(`Could not inflate layout for perspective '${perspId}'`, error);
                 }
@@ -253,7 +243,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                     const layout = await this.inflate(legacyData);
                     this.transformations.getContributions()
                         .forEach(t => t.transformLayoutOnRestore(layout));
-                    this.perspectiveProvider.setSavedLayout('default', layout);
+                    this.perspectiveService.setSavedLayout('default', layout);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
                 }
@@ -263,18 +253,18 @@ export class ShellLayoutRestorer implements CommandContribution {
         }
 
         if (activeId) {
-            const accepted = this.perspectiveProvider.setActivePerspectiveId(activeId);
+            const accepted = this.perspectiveService.setActivePerspectiveId(activeId);
             if (!accepted) {
-                activeId = this.perspectiveProvider.getActivePerspectiveId();
+                activeId = this.perspectiveService.getActivePerspectiveId();
             }
         }
 
         // Apply the active perspective's layout to the shell
-        const effectiveId = activeId ?? this.perspectiveProvider.getActivePerspectiveId();
-        const activeLayout = this.perspectiveProvider.getSavedLayout(effectiveId);
+        const effectiveId = activeId ?? this.perspectiveService.getActivePerspectiveId();
+        const activeLayout = this.perspectiveService.getSavedLayout(effectiveId);
         if (activeLayout) {
             await app.shell.setLayoutData(activeLayout);
-            this.perspectiveProvider.onLayoutRestored(effectiveId);
+            this.perspectiveService.onLayoutRestored(effectiveId);
             this.logger.info('<<< The layout has been successfully restored.');
             return true;
         }

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -124,6 +124,24 @@ export interface ShellLayoutTransformer {
     transformLayoutOnRestore(layoutData: ApplicationShell.LayoutData): void;
 }
 
+export const PERSPECTIVE_LAYOUTS_STORAGE_KEY = 'layouts';
+
+export interface PersistedPerspectiveData {
+    activePerspectiveId: string;
+    layouts: Record<string, string>;
+}
+
+export const PerspectiveLayoutProvider = Symbol('PerspectiveLayoutProvider');
+export interface PerspectiveLayoutProvider {
+    getActivePerspectiveId(): string;
+    getSavedPerspectiveIds(): string[];
+    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
+    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
+    setActivePerspectiveId(id: string): void;
+    clearSavedLayouts(): void;
+    onLayoutRestored(activePerspectiveId: string): void;
+}
+
 export const RESET_LAYOUT = Command.toLocalizedCommand({
     id: 'reset.layout',
     category: CommonCommands.VIEW_CATEGORY,
@@ -133,13 +151,16 @@ export const RESET_LAYOUT = Command.toLocalizedCommand({
 @injectable()
 export class ShellLayoutRestorer implements CommandContribution {
 
-    protected storageKey = 'layout';
+    protected readonly legacyStorageKey = 'layout';
     protected shouldStoreLayout: boolean = true;
 
     @inject(ContributionProvider) @named(ApplicationShellLayoutMigration) protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
     @inject(ContributionProvider) @named(ShellLayoutTransformer) protected readonly transformations: ContributionProvider<ShellLayoutTransformer>;
     @inject(WindowService) protected readonly windowService: WindowService;
     @inject(ThemeService) protected readonly themeService: ThemeService;
+
+    @inject(PerspectiveLayoutProvider)
+    protected readonly perspectiveProvider: PerspectiveLayoutProvider;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -156,7 +177,9 @@ export class ShellLayoutRestorer implements CommandContribution {
         if (await this.windowService.isSafeToShutDown(StopReason.Reload)) {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
-            this.storageService.setData(this.storageKey, undefined);
+            this.storageService.setData(this.legacyStorageKey, undefined);
+            this.perspectiveProvider.clearSavedLayouts();
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
             this.themeService.reset();
             this.logger.info('<<< The layout has been successfully reset.');
             this.windowService.reload();
@@ -167,29 +190,95 @@ export class ShellLayoutRestorer implements CommandContribution {
         if (this.shouldStoreLayout) {
             try {
                 this.logger.info('>>> Storing the layout...');
-                const layoutData = app.shell.getLayoutData();
-                const serializedLayoutData = this.deflate(layoutData);
-                this.storageService.setData(this.storageKey, serializedLayoutData);
+                this.storePerspectiveLayouts(app);
                 this.logger.info('<<< The layout has been successfully stored.');
             } catch (error) {
-                this.storageService.setData(this.storageKey, undefined);
                 this.logger.error('Error during serialization of layout data', error);
             }
         }
     }
 
+    protected storePerspectiveLayouts(app: FrontendApplication): void {
+        const provider = this.perspectiveProvider;
+        const activeId = provider.getActivePerspectiveId();
+        const layouts: Record<string, string> = {};
+
+        // Snapshot current shell as the active perspective's layout
+        const currentLayout = app.shell.getLayoutData();
+        layouts[activeId] = this.deflate(currentLayout);
+
+        // Deflate all other saved (inactive) perspective layouts
+        for (const perspId of provider.getSavedPerspectiveIds()) {
+            if (perspId === activeId) {
+                continue; // already handled above from live shell
+            }
+            const layout = provider.getSavedLayout(perspId);
+            if (layout) {
+                layouts[perspId] = this.deflate(layout);
+            }
+        }
+
+        const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
+        this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data);
+    }
+
     async restoreLayout(app: FrontendApplication): Promise<boolean> {
         this.logger.info('>>> Restoring the layout state...');
-        const serializedLayoutData = await this.storageService.getData<string>(this.storageKey);
-        if (serializedLayoutData === undefined) {
-            this.logger.info('<<< Nothing to restore.');
-            return false;
+        return this.restorePerspectiveLayouts(app);
+    }
+
+    protected async restorePerspectiveLayouts(app: FrontendApplication): Promise<boolean> {
+        const persisted = await this.storageService.getData<PersistedPerspectiveData>(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+
+        let activeId: string | undefined;
+
+        if (persisted) {
+            activeId = persisted.activePerspectiveId;
+            // Inflate all perspective layouts and push to provider
+            for (const [perspId, deflated] of Object.entries(persisted.layouts)) {
+                try {
+                    const layout = await this.inflate(deflated);
+                    this.perspectiveProvider.setSavedLayout(perspId, layout);
+                } catch (error) {
+                    this.logger.warn(`Could not inflate layout for perspective '${perspId}'`, error);
+                }
+            }
+        } else {
+            // Migration: try legacy single-layout key
+            const legacyData = await this.storageService.getData<string>(this.legacyStorageKey);
+            if (legacyData) {
+                try {
+                    const layout = await this.inflate(legacyData);
+                    this.perspectiveProvider.setSavedLayout('default', layout);
+                } catch (error) {
+                    this.logger.warn('Could not inflate legacy layout for migration', error);
+                }
+                activeId = 'default';
+                this.storageService.setData(this.legacyStorageKey, undefined);
+            }
         }
-        const layoutData = await this.inflate(serializedLayoutData);
-        this.transformations.getContributions().forEach(transformation => transformation.transformLayoutOnRestore(layoutData));
-        await app.shell.setLayoutData(layoutData);
-        this.logger.info('<<< The layout has been successfully restored.');
-        return true;
+
+        if (activeId) {
+            this.perspectiveProvider.setActivePerspectiveId(activeId);
+        }
+
+        // Apply the active perspective's layout to the shell
+        const activeLayout = this.perspectiveProvider.getSavedLayout(
+            activeId ?? this.perspectiveProvider.getActivePerspectiveId()
+        );
+        if (activeLayout) {
+            this.transformations.getContributions()
+                .forEach(t => t.transformLayoutOnRestore(activeLayout));
+            await app.shell.setLayoutData(activeLayout);
+            this.perspectiveProvider.onLayoutRestored(
+                activeId ?? this.perspectiveProvider.getActivePerspectiveId()
+            );
+            this.logger.info('<<< The layout has been successfully restored.');
+            return true;
+        }
+
+        this.logger.info('<<< Nothing to restore.');
+        return false;
     }
 
     protected isWidgetProperty(propertyName: string): boolean {
@@ -203,7 +292,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     /**
      * Turns the layout data to a string representation.
      */
-    protected deflate(data: object): string {
+    deflate(data: object): string {
         return JSON.stringify(data, (property: string, value) => {
             if (this.isWidgetProperty(property)) {
                 const description = this.convertToDescription(value as Widget);
@@ -243,7 +332,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     /**
      * Creates the layout data from its string representation.
      */
-    protected async inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
+    async inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
         const parseContext = new ShellLayoutRestorer.ParseContext();
         const layout = this.parse<ApplicationShell.LayoutData>(layoutData, parseContext);
 

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -216,13 +216,11 @@ export class ShellLayoutRestorer implements CommandContribution {
             }
         }
 
-        try {
-            const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
-            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data);
-        } catch (error) {
+        const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
+        this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data).catch(error => {
             this.logger.error('Error persisting perspective layouts, clearing stored data', error);
             this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
-        }
+        });
     }
 
     async restoreLayout(app: FrontendApplication): Promise<boolean> {

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -194,22 +194,35 @@ export class ShellLayoutRestorer implements CommandContribution {
         const layouts: Record<string, string> = {};
 
         // Snapshot current shell as the active perspective's layout
-        const currentLayout = app.shell.getLayoutData();
-        layouts[activeId] = this.deflate(currentLayout);
+        try {
+            const currentLayout = app.shell.getLayoutData();
+            layouts[activeId] = this.deflate(currentLayout);
+        } catch (error) {
+            this.logger.warn(`Could not deflate layout for active perspective '${activeId}'`, error);
+        }
 
         // Deflate all other saved (inactive) perspective layouts
         for (const perspId of provider.getSavedPerspectiveIds()) {
             if (perspId === activeId) {
                 continue; // already handled above from live shell
             }
-            const layout = provider.getSavedLayout(perspId);
-            if (layout) {
-                layouts[perspId] = this.deflate(layout);
+            try {
+                const layout = provider.getSavedLayout(perspId);
+                if (layout) {
+                    layouts[perspId] = this.deflate(layout);
+                }
+            } catch (error) {
+                this.logger.warn(`Could not deflate layout for perspective '${perspId}'`, error);
             }
         }
 
-        const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
-        this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data);
+        try {
+            const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data);
+        } catch (error) {
+            this.logger.error('Error persisting perspective layouts, clearing stored data', error);
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
+        }
     }
 
     async restoreLayout(app: FrontendApplication): Promise<boolean> {
@@ -243,11 +256,11 @@ export class ShellLayoutRestorer implements CommandContribution {
                     const layout = await this.inflate(legacyData);
                     this.transformations.getContributions()
                         .forEach(t => t.transformLayoutOnRestore(layout));
-                    this.perspectiveService.setSavedLayout('default', layout);
+                    this.perspectiveService.setSavedLayout(this.perspectiveService.defaultPerspectiveId, layout);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
                 }
-                activeId = 'default';
+                activeId = this.perspectiveService.defaultPerspectiveId;
                 this.storageService.setData(this.legacyStorageKey, undefined);
             }
         }
@@ -261,14 +274,26 @@ export class ShellLayoutRestorer implements CommandContribution {
 
         // Apply the active perspective's layout to the shell
         const effectiveId = activeId ?? this.perspectiveService.getActivePerspectiveId();
-        const activeLayout = this.perspectiveService.getSavedLayout(effectiveId);
+        let activeLayout = this.perspectiveService.getSavedLayout(effectiveId);
+
+        // Fallback: if the active perspective has no saved layout, try the default
+        if (!activeLayout && effectiveId !== this.perspectiveService.defaultPerspectiveId) {
+            this.logger.warn(`No saved layout for perspective '${effectiveId}', falling back to default.`);
+            const defaultId = this.perspectiveService.defaultPerspectiveId;
+            this.perspectiveService.setActivePerspectiveId(defaultId);
+            activeLayout = this.perspectiveService.getSavedLayout(defaultId);
+        }
+
         if (activeLayout) {
             await app.shell.setLayoutData(activeLayout);
-            this.perspectiveService.onLayoutRestored(effectiveId);
+            const restoredId = this.perspectiveService.getActivePerspectiveId();
+            this.perspectiveService.onLayoutRestored(restoredId);
             this.logger.info('<<< The layout has been successfully restored.');
             return true;
         }
 
+        // Even with no layout to restore, ensure chrome is applied for whatever perspective is active
+        this.perspectiveService.onLayoutRestored(this.perspectiveService.getActivePerspectiveId());
         this.logger.info('<<< Nothing to restore.');
         return false;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- integrate the Perspective Service with the Layout Restorer
- persist perspective-specific layouts under 'layouts' and unset the current 'layout' key

#### How to test

- Open both perspectives (F1 > Switch perspective > AI First / Default)
- Rearrange some views or panels
- Close and reopen the application
- Check: both perspectives should still be in their latest known state

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
