### PR TITLE
feat: add AI Sessions view and add it to the AI First perspective

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -21,6 +21,7 @@ import {
 } from '@theia/core';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { ConfirmDialog, FrontendApplicationContribution, KeybindingRegistry, Widget } from '@theia/core/lib/browser';
+import { PerspectiveService } from '@theia/core/lib/browser/perspective-service';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import {
     AI_CHAT_HOME,
@@ -77,6 +78,9 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
     protected readonly logger: ILogger;
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(PerspectiveService)
+    protected readonly perspectiveService: PerspectiveService;
 
     /**
      * Store whether there are persisted sessions to make this information available in
@@ -147,6 +151,10 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
 
         this.checkPersistedSessions();
         this.attachToActiveSession();
+
+        this.perspectiveService.onDidChangePerspective(() => {
+            this.onActiveSessionEmptyChangedEmitter.fire();
+        });
 
         this.chatViewActiveKey = this.contextKeyService.createKey<boolean>('chatViewActive', false);
         this.updateChatViewActiveKey();
@@ -393,7 +401,10 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             onDidChange: this.onActiveSessionEmptyChangedEmitter.event,
             // Hide on the overview itself (the active session is empty); only show when there
             // is an actual chat to return from.
-            isVisible: widget => this.activationService.isActive && this.withWidget(widget) && !this.activeSessionEmpty,
+            isVisible: widget => this.activationService.isActive
+                && this.withWidget(widget)
+                && !this.activeSessionEmpty
+                && this.perspectiveService.getActivePerspectiveId() !== 'ai-first',
             when: ENABLE_AI_CONTEXT_KEY
         });
         registry.registerItem({

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -26,6 +26,7 @@ import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-k
 import {
     AI_CHAT_HOME,
     AI_CHAT_SHOW_CHATS_COMMAND,
+    AI_FIRST_PERSPECTIVE_ID,
     ChatCommands
 } from './chat-view-commands';
 import { ChatAgent, ChatAgentLocation, ChatService, ChatSessionMetadata, isActiveSessionChangedEvent } from '@theia/ai-chat';
@@ -404,7 +405,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             isVisible: widget => this.activationService.isActive
                 && this.withWidget(widget)
                 && !this.activeSessionEmpty
-                && this.perspectiveService.getActivePerspectiveId() !== 'ai-first',
+                && this.perspectiveService.getActivePerspectiveId() !== AI_FIRST_PERSPECTIVE_ID,
             when: ENABLE_AI_CONTEXT_KEY
         });
         registry.registerItem({

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -25,6 +25,7 @@ import { PerspectiveService } from '@theia/core/lib/browser/perspective-service'
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import {
     AI_CHAT_HOME,
+    AI_CHAT_OPEN_SESSION,
     AI_CHAT_SHOW_CHATS_COMMAND,
     AI_FIRST_PERSPECTIVE_ID,
     ChatCommands
@@ -303,6 +304,18 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             },
             isVisible: () => this.activationService.isActive,
             isEnabled: () => this.activationService.canRun
+        });
+        registry.registerCommand(AI_CHAT_OPEN_SESSION, {
+            execute: async (sessionId: string) => {
+                const session = await this.chatService.getOrRestoreSession(sessionId);
+                if (!session) {
+                    throw new Error(`Chat session '${sessionId}' not found`);
+                }
+                await this.openView({ activate: true });
+                this.chatService.setActiveSession(sessionId, { focus: false });
+            },
+            isVisible: () => this.activationService.isActive,
+            isEnabled: () => this.activationService.canRun,
         });
         registry.registerCommand(AI_CHAT_SHOW_CHATS_COMMAND, {
             execute: async () => {

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -314,8 +314,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                 await this.openView({ activate: true });
                 this.chatService.setActiveSession(sessionId, { focus: false });
             },
-            isVisible: () => this.activationService.isActive,
-            isEnabled: () => this.activationService.canRun,
+            isVisible: () => false,
         });
         registry.registerCommand(AI_CHAT_SHOW_CHATS_COMMAND, {
             execute: async () => {

--- a/packages/ai-chat-ui/src/browser/chat-view-commands.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-commands.ts
@@ -101,3 +101,9 @@ export const AI_CHAT_SHOW_CHATS_COMMAND = Command.toLocalizedCommand({
     category: ChatCommands.CHAT_CATEGORY,
     label: 'Browse all chats...'
 }, 'theia/ai-chat-ui/browseAllChats');
+
+export const AI_CHAT_OPEN_SESSION = Command.toLocalizedCommand({
+    id: 'ai-chat-ui.open-session',
+    category: ChatCommands.CHAT_CATEGORY,
+    label: 'Open Chat Session'
+}, 'theia/ai-chat-ui/openSession', ChatCommands.CHAT_CATEGORY_KEY);

--- a/packages/ai-chat-ui/src/browser/chat-view-commands.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-commands.ts
@@ -93,6 +93,8 @@ export const AI_CHAT_HOME = Command.toLocalizedCommand({
     label: 'Home'
 }, 'theia/ai-chat-ui/home', ChatCommands.CHAT_CATEGORY_KEY);
 
+export const AI_FIRST_PERSPECTIVE_ID = 'ai-first';
+
 export const AI_CHAT_SHOW_CHATS_COMMAND = Command.toLocalizedCommand({
     id: 'ai-chat-ui.show-chats',
     iconClass: codicon('history'),

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -107,7 +107,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         layout.addWidget(this.treeWidget);
         this.inputWidget.node.classList.add('chat-input-widget');
         layout.addWidget(this.inputWidget);
-        this.chatSession = this.chatService.getActiveSession() ?? this.chatService.createSession();
+        this.chatSession = this.chatService.createSession();
 
         this.inputWidget.onQuery = this.onQuery.bind(this);
         this.inputWidget.onUnpin = this.onUnpin.bind(this);

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -107,7 +107,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         layout.addWidget(this.treeWidget);
         this.inputWidget.node.classList.add('chat-input-widget');
         layout.addWidget(this.inputWidget);
-        this.chatSession = this.chatService.createSession();
+        this.chatSession = this.chatService.getActiveSession() ?? this.chatService.createSession();
 
         this.inputWidget.onQuery = this.onQuery.bind(this);
         this.inputWidget.onUnpin = this.onUnpin.bind(this);

--- a/packages/ai-chat/src/common/chat-service-session-events.spec.ts
+++ b/packages/ai-chat/src/common/chat-service-session-events.spec.ts
@@ -1,0 +1,161 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import {
+    ActiveSessionChangedEvent,
+    ChatServiceImpl,
+    DefaultChatAgentId,
+    PinChatAgent,
+    SessionCreatedEvent,
+    SessionDeletedEvent,
+    SessionRenamedEvent
+} from './chat-service';
+import { ChatAgentService } from './chat-agent-service';
+import { ChatRequestParser } from './chat-request-parser';
+import { AIVariableService, ToolInvocationRegistry } from '@theia/ai-core';
+import { ILogger } from '@theia/core';
+import { ChatContentDeserializerRegistry, ChatContentDeserializerRegistryImpl, DefaultChatContentDeserializerContribution } from './chat-content-deserializer';
+import { ChangeSetElementDeserializerRegistry, ChangeSetElementDeserializerRegistryImpl } from './change-set-element-deserializer';
+import { ChatAgent, ChatAgentLocation } from './chat-agents';
+import { ChatRequest } from './chat-model';
+import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
+
+describe('ChatService session events', () => {
+    let chatService: ChatServiceImpl;
+    let container: Container;
+
+    const mockDefaultAgent: ChatAgent = {
+        id: 'default-agent',
+        name: 'Default Agent',
+        description: 'Test default agent',
+        locations: [ChatAgentLocation.Panel],
+        invoke: async () => { },
+        languageModelRequirements: [],
+        tags: [],
+        variables: [],
+        agentSpecificVariables: [],
+        functions: [],
+        prompts: []
+    };
+
+    class MockChatAgentService {
+        readonly onDidChangeAgents = { dispose: () => { } };
+        readonly onDefaultAgentChanged = { dispose: () => { } };
+
+        getAgent(id: string): ChatAgent | undefined {
+            return id === 'default-agent' ? mockDefaultAgent : undefined;
+        }
+
+        resolveAgent(): ChatAgent | undefined {
+            return mockDefaultAgent;
+        }
+    }
+
+    class MockChatRequestParser {
+        async parseChatRequest(request: ChatRequest): Promise<ParsedChatRequest> {
+            return {
+                request,
+                parts: [new ParsedChatRequestTextPart({ start: 0, endExclusive: request.text.length }, request.text)],
+                toolRequests: new Map(),
+                variables: []
+            };
+        }
+    }
+
+    class MockAIVariableService {
+        async resolveVariable(): Promise<unknown> {
+            return undefined;
+        }
+    }
+
+    class MockLogger {
+        error(): void { }
+        warn(): void { }
+        info(): void { }
+        debug(): void { }
+    }
+
+    beforeEach(() => {
+        container = new Container();
+
+        container.bind(ChatAgentService).toConstantValue(new MockChatAgentService() as unknown as ChatAgentService);
+        container.bind(ChatRequestParser).toConstantValue(new MockChatRequestParser() as unknown as ChatRequestParser);
+        container.bind(AIVariableService).toConstantValue(new MockAIVariableService() as unknown as AIVariableService);
+        container.bind(ToolInvocationRegistry).toConstantValue({});
+        container.bind(ILogger).toConstantValue(new MockLogger() as unknown as ILogger);
+
+        container.bind(DefaultChatAgentId).toConstantValue({ id: 'default-agent' });
+        container.bind(PinChatAgent).toConstantValue(true);
+
+        const contentRegistry = new ChatContentDeserializerRegistryImpl();
+        new DefaultChatContentDeserializerContribution().registerDeserializers(contentRegistry);
+        container.bind(ChatContentDeserializerRegistry).toConstantValue(contentRegistry);
+        container.bind(ChangeSetElementDeserializerRegistry).toConstantValue(new ChangeSetElementDeserializerRegistryImpl());
+        container.bind(ChatServiceImpl).toSelf().inSingletonScope();
+
+        chatService = container.get(ChatServiceImpl);
+    });
+
+    it('should fire a renamed event when sendRequest sets the session title', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+        expect(session.title).to.be.undefined;
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        await chatService.sendRequest(session.id, { text: 'Hello world' });
+
+        expect(session.title).to.equal('Hello world');
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(1);
+        expect((renamedEvents[0] as SessionRenamedEvent).sessionId).to.equal(session.id);
+    });
+
+    it('should not fire a renamed event on subsequent requests when title is already set', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+
+        // First request sets the title
+        await chatService.sendRequest(session.id, { text: 'First message' });
+        expect(session.title).to.equal('First message');
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        // Second request should not trigger a renamed event
+        await chatService.sendRequest(session.id, { text: 'Second message' });
+
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(0);
+        // Title should remain the first message
+        expect(session.title).to.equal('First message');
+    });
+
+    it('should fire a renamed event via renameSession', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        await chatService.renameSession(session.id, 'New Title');
+
+        expect(session.title).to.equal('New Title');
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(1);
+        expect((renamedEvents[0] as SessionRenamedEvent).sessionId).to.equal(session.id);
+    });
+});

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -351,6 +351,7 @@ export class ChatServiceImpl implements ChatService {
         }
         const requestText = request.request.displayText ?? request.request.text;
         session.title = requestText;
+        this.onSessionEventEmitter.fire({ type: 'renamed', sessionId: session.id });
         if (this.chatSessionNamingService) {
             const otherSessionNames = this._sessions.map(s => s.title).filter((title): title is string => title !== undefined);
             const namingService = this.chatSessionNamingService;
@@ -362,6 +363,7 @@ export class ChatServiceImpl implements ChatService {
                             session.title = name;
                             // Trigger persistence when title changes
                             this.saveSession(session.id);
+                            this.onSessionEventEmitter.fire({ type: 'renamed', sessionId: session.id });
                         }
                         didGenerateName = true;
                     }).catch(error => this.logger.error('Failed to generate chat session name', error));

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -21,6 +21,7 @@ import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shel
 import { EXPLORER_VIEW_CONTAINER_ID } from '@theia/navigator/lib/browser';
 import { SCM_VIEW_CONTAINER_ID } from '@theia/scm/lib/browser/scm-contribution';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { AI_FIRST_PERSPECTIVE_ID } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AISessionsWidget } from './ai-sessions-widget';
 
 @injectable()
@@ -32,7 +33,7 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
             collapseAreas: ['bottom']
         };
         service.registerPerspective({
-            id: 'ai-first',
+            id: AI_FIRST_PERSPECTIVE_ID,
             label: nls.localize('theia/ai-ide/perspective/aiFirst', 'AI First'),
             viewPlacements: new Map<string, ApplicationShell.Area>([
                 [ChatViewWidget.ID, 'main'],

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -21,6 +21,7 @@ import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shel
 import { EXPLORER_VIEW_CONTAINER_ID } from '@theia/navigator/lib/browser';
 import { SCM_VIEW_CONTAINER_ID } from '@theia/scm/lib/browser/scm-contribution';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { AISessionsWidget } from './ai-sessions-widget';
 
 @injectable()
 export class AIFirstPerspectiveContribution implements PerspectiveContribution {
@@ -28,7 +29,7 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
     registerPerspectives(service: PerspectiveService): void {
         const chromeOptions: PerspectiveChromeOptions = {
             hideStatusBar: true,
-            collapseAreas: ['left', 'bottom']
+            collapseAreas: ['bottom']
         };
         service.registerPerspective({
             id: 'ai-first',
@@ -36,7 +37,8 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
             viewPlacements: new Map<string, ApplicationShell.Area>([
                 [ChatViewWidget.ID, 'main'],
                 [EXPLORER_VIEW_CONTAINER_ID, 'right'],
-                [SCM_VIEW_CONTAINER_ID, 'right']
+                [SCM_VIEW_CONTAINER_ID, 'right'],
+                [AISessionsWidget.ID, 'left']
             ]),
             chromeOptions
         });

--- a/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
@@ -14,14 +14,29 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AIViewContribution } from '@theia/ai-core/lib/browser';
-import { injectable } from '@theia/core/shared/inversify';
+import { ChatAgentLocation, ChatService } from '@theia/ai-chat';
+import { ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { AIViewContribution, ENABLE_AI_CONTEXT_KEY } from '@theia/ai-core/lib/browser';
+import { Command, CommandRegistry, nls } from '@theia/core';
+import { codicon } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { AISessionsWidget } from './ai-sessions-widget';
 
 export const AI_SESSIONS_TOGGLE_COMMAND_ID = 'aiSessions:toggle';
 
+export const AI_SESSIONS_NEW_SESSION = Command.toLocalizedCommand({
+    id: 'aiSessions:newSession',
+    iconClass: codicon('add'),
+    category: ChatCommands.CHAT_CATEGORY,
+    label: 'New Chat'
+}, 'theia/ai-ide/newChat', ChatCommands.CHAT_CATEGORY_KEY);
+
 @injectable()
-export class AISessionsViewContribution extends AIViewContribution<AISessionsWidget> {
+export class AISessionsViewContribution extends AIViewContribution<AISessionsWidget> implements TabBarToolbarContribution {
+
+    @inject(ChatService)
+    protected readonly chatService: ChatService;
 
     constructor() {
         super({
@@ -31,6 +46,30 @@ export class AISessionsViewContribution extends AIViewContribution<AISessionsWid
                 area: 'left'
             },
             toggleCommandId: AI_SESSIONS_TOGGLE_COMMAND_ID
+        });
+    }
+
+    override registerCommands(commands: CommandRegistry): void {
+        super.registerCommands(commands);
+        commands.registerCommand(AI_SESSIONS_NEW_SESSION, this.commandHandlerFactory({
+            execute: () => {
+                const activeSession = this.chatService.getActiveSession();
+                if (activeSession?.model.isEmpty()) {
+                    this.chatService.setActiveSession(activeSession.id, { focus: true });
+                } else {
+                    this.chatService.createSession(ChatAgentLocation.Panel, { focus: true });
+                }
+            }
+        }));
+    }
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: AI_SESSIONS_NEW_SESSION.id,
+            command: AI_SESSIONS_NEW_SESSION.id,
+            tooltip: nls.localizeByDefault('New Chat'),
+            isVisible: widget => this.activationService.isActive && widget instanceof AISessionsWidget,
+            when: ENABLE_AI_CONTEXT_KEY
         });
     }
 }

--- a/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AIViewContribution } from '@theia/ai-core/lib/browser';
+import { injectable } from '@theia/core/shared/inversify';
+import { AISessionsWidget } from './ai-sessions-widget';
+
+export const AI_SESSIONS_TOGGLE_COMMAND_ID = 'aiSessions:toggle';
+
+@injectable()
+export class AISessionsViewContribution extends AIViewContribution<AISessionsWidget> {
+
+    constructor() {
+        super({
+            widgetId: AISessionsWidget.ID,
+            widgetName: AISessionsWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'left'
+            },
+            toggleCommandId: AI_SESSIONS_TOGGLE_COMMAND_ID
+        });
+    }
+}

--- a/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
@@ -14,8 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ChatAgentLocation, ChatService } from '@theia/ai-chat';
-import { ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { AI_CHAT_HOME, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AIViewContribution, ENABLE_AI_CONTEXT_KEY } from '@theia/ai-core/lib/browser';
 import { Command, CommandRegistry, nls } from '@theia/core';
 import { codicon } from '@theia/core/lib/browser';
@@ -35,8 +34,8 @@ export const AI_SESSIONS_NEW_SESSION = Command.toLocalizedCommand({
 @injectable()
 export class AISessionsViewContribution extends AIViewContribution<AISessionsWidget> implements TabBarToolbarContribution {
 
-    @inject(ChatService)
-    protected readonly chatService: ChatService;
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
 
     constructor() {
         super({
@@ -52,14 +51,7 @@ export class AISessionsViewContribution extends AIViewContribution<AISessionsWid
     override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(AI_SESSIONS_NEW_SESSION, this.commandHandlerFactory({
-            execute: () => {
-                const activeSession = this.chatService.getActiveSession();
-                if (activeSession?.model.isEmpty()) {
-                    this.chatService.setActiveSession(activeSession.id, { focus: true });
-                } else {
-                    this.chatService.createSession(ChatAgentLocation.Panel, { focus: true });
-                }
-            }
+            execute: () => this.commandRegistry.executeCommand(AI_CHAT_HOME.id)
         }));
     }
 

--- a/packages/ai-ide/src/browser/ai-sessions-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-sessions-widget.tsx
@@ -14,12 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ChatAgentService, ChatService, ChatSessionMetadata } from '@theia/ai-chat';
-import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
-import { ChatSessionItemAction, ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
-import { ChatSessionItem } from './chat-session-item';
+import { ChatAgentService, ChatService } from '@theia/ai-chat';
+import { ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
 import { ChatSessionListService } from './chat-session-list-service';
-import { SessionsList } from './chat-session-list-components';
+import { createSessionItemRenderer, SessionsList } from './chat-session-list-components';
 import { CommandRegistry, ContributionProvider, nls } from '@theia/core';
 import { codicon, HoverService, ReactWidget } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
@@ -61,6 +59,22 @@ export class AISessionsWidget extends ReactWidget {
         return this._markdownRenderer;
     }
 
+    protected sessionItemRenderer: ReturnType<typeof createSessionItemRenderer> | undefined;
+    protected getSessionItemRenderer(): ReturnType<typeof createSessionItemRenderer> {
+        if (!this.sessionItemRenderer) {
+            this.sessionItemRenderer = createSessionItemRenderer({
+                chatService: this.chatService,
+                chatAgentService: this.chatAgentService,
+                hoverService: this.hoverService,
+                markdownRenderer: this.markdownRenderer,
+                commandRegistry: this.commandRegistry,
+                unreadState: this.sessionListService,
+                chatSessionItemActionContributions: this.chatSessionItemActionContributions
+            });
+        }
+        return this.sessionItemRenderer;
+    }
+
     @postConstruct()
     protected init(): void {
         this.id = AISessionsWidget.ID;
@@ -96,43 +110,10 @@ export class AISessionsWidget extends ReactWidget {
                 <SessionsList
                     sections={sections}
                     maxSessions={Number.MAX_SAFE_INTEGER}
-                    renderItem={this.renderSessionItem}
+                    renderItem={this.getSessionItemRenderer().renderSessionItem}
                     onBrowseAll={() => { }}
                 />
             </div>
         );
     }
-
-    protected renderSessionItem = (session: ChatSessionMetadata, isRestored: boolean): React.ReactNode => {
-        const actions = this.chatSessionItemActionContributions
-            .getContributions()
-            .flatMap(c => c.getActions(session))
-            .filter(action => this.commandRegistry.isEnabled(action.commandId, session))
-            .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
-        return (
-            <ChatSessionItem
-                key={session.sessionId}
-                session={session}
-                isRestored={isRestored}
-                chatService={this.chatService}
-                chatAgentService={this.chatAgentService}
-                hoverService={this.hoverService}
-                markdownRenderer={this.markdownRenderer}
-                unreadState={this.sessionListService}
-                onClick={() => this.handleSessionItemClick(session.sessionId)}
-                actions={actions}
-                onAction={this.handleSessionItemAction}
-                formatTimeAgo={date => formatTimeAgo(date)}
-            />
-        );
-    };
-
-    protected handleSessionItemAction = (action: ChatSessionItemAction, session: ChatSessionMetadata): void => {
-        this.commandRegistry.executeCommand(action.commandId, session);
-    };
-
-    protected handleSessionItemClick = async (sessionId: string): Promise<void> => {
-        await this.chatService.getOrRestoreSession(sessionId);
-        this.chatService.setActiveSession(sessionId, { focus: true });
-    };
 }

--- a/packages/ai-ide/src/browser/ai-sessions-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-sessions-widget.tsx
@@ -14,40 +14,35 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
+import { ChatAgentService, ChatService, ChatSessionMetadata } from '@theia/ai-chat';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
-import {
-    ChatAgentService, ChatService, ChatSessionMetadata
-} from '@theia/ai-chat';
-import { BYPASS_MODEL_REQUIREMENT_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
-import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { ChatSessionItemAction, ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
 import { ChatSessionItem } from './chat-session-item';
 import { ChatSessionListService } from './chat-session-list-service';
-import { SectionedSessions, SessionsList } from './chat-session-list-components';
-import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
-import { CommandRegistry, ContributionProvider, Emitter, Event, PreferenceService } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { SessionsList } from './chat-session-list-components';
+import { CommandRegistry, ContributionProvider, nls } from '@theia/core';
+import { codicon, HoverService, ReactWidget } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 
 @injectable()
-export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessageProvider {
+export class AISessionsWidget extends ReactWidget {
 
-    readonly priority = 50;
+    static readonly ID = 'ai-sessions-widget';
+    static readonly LABEL = nls.localize('theia/ai-ide/sessionsView', 'AI Sessions');
+
+    @inject(ChatSessionListService)
+    protected readonly sessionListService: ChatSessionListService;
 
     @inject(ChatService)
     protected readonly chatService: ChatService;
 
-    @inject(CommandRegistry)
-    protected readonly commandRegistry: CommandRegistry;
-
-    @inject(PreferenceService)
-    protected readonly preferenceService: PreferenceService;
-
     @inject(ChatAgentService)
     protected readonly chatAgentService: ChatAgentService;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
@@ -58,14 +53,6 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
     @inject(ContributionProvider) @named(ChatSessionItemActionContribution)
     protected readonly chatSessionItemActionContributions: ContributionProvider<ChatSessionItemActionContribution>;
 
-    @inject(FrontendLanguageModelRegistry)
-    protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
-
-    @inject(ChatSessionListService)
-    protected readonly sessionListService: ChatSessionListService;
-
-    protected _inputEnabled = false;
-
     protected _markdownRenderer: MarkdownRenderer | undefined;
     protected get markdownRenderer(): MarkdownRenderer {
         if (!this._markdownRenderer) {
@@ -74,63 +61,44 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         return this._markdownRenderer;
     }
 
-    protected readonly onStateChangedEmitter = new Emitter<void>();
-    readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
-
     @postConstruct()
     protected init(): void {
-        this.sessionListService.onStateChanged(() => {
-            this.onStateChangedEmitter.fire();
-        });
+        this.id = AISessionsWidget.ID;
+        this.title.label = AISessionsWidget.LABEL;
+        this.title.caption = AISessionsWidget.LABEL;
+        this.title.closable = true;
+        this.title.iconClass = codicon('history');
+        this.addClass('ai-sessions-view');
 
-        this.updateInputEnabled();
-        this.languageModelRegistry.onChange(() => {
-            this.updateInputEnabled();
-        });
-        this.preferenceService.onPreferenceChanged(e => {
-            if (e.preferenceName === BYPASS_MODEL_REQUIREMENT_PREF) {
-                this.updateInputEnabled();
-            } else if (e.preferenceName === WELCOME_SCREEN_SESSIONS_PREF) {
-                this.onStateChangedEmitter.fire();
-            }
-        });
+        this.toDispose.pushAll([
+            this.sessionListService.onStateChanged(() => this.update()),
+            this.sessionListService.onUnreadChanged(() => this.update())
+        ]);
+
+        this.update();
     }
 
-    protected async updateInputEnabled(): Promise<void> {
-        const models = await this.languageModelRegistry.getLanguageModels();
-        const hasReadyModels = models.some(model => model.status.status === 'ready');
-        const bypassed = this.preferenceService.get<boolean>(BYPASS_MODEL_REQUIREMENT_PREF, false);
-        const enabled = hasReadyModels || bypassed;
-        if (this._inputEnabled !== enabled) {
-            this._inputEnabled = enabled;
-            this.onStateChangedEmitter.fire();
-        }
-    }
-
-    renderWelcomeMessage(): React.ReactNode {
-        if (!this._inputEnabled) {
-            return undefined;
-        }
+    protected render(): React.ReactNode {
         const sections = this.sessionListService.getSections();
-        const sessionCount = sections.active.length + sections.restored.length;
-        if (!this.sessionListService.isPersistenceEnabled() || sessionCount === 0) {
-            return undefined;
-        }
-        return this.renderSessionsSection(sections);
-    }
+        const total = sections.active.length + sections.restored.length;
 
-    protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
-        const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
-        return (
-            <div className="theia-WelcomeMessage" key="sessions-section">
-                <div className="theia-WelcomeMessage-SessionsSection">
-                    <SessionsList
-                        sections={sections}
-                        maxSessions={maxSessions}
-                        renderItem={this.renderSessionItem}
-                        onBrowseAll={this.handleBrowseAllChats}
-                    />
+        if (total === 0) {
+            return (
+                <div className="ai-sessions-view-empty">
+                    <span className={codicon('comment-discussion')} />
+                    <p>{nls.localize('theia/ai-ide/noSessions', 'No chat sessions yet.')}</p>
                 </div>
+            );
+        }
+
+        return (
+            <div className="ai-sessions-view-content">
+                <SessionsList
+                    sections={sections}
+                    maxSessions={Number.MAX_SAFE_INTEGER}
+                    renderItem={this.renderSessionItem}
+                    onBrowseAll={() => { }}
+                />
             </div>
         );
     }
@@ -166,9 +134,5 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
     protected handleSessionItemClick = async (sessionId: string): Promise<void> => {
         await this.chatService.getOrRestoreSession(sessionId);
         this.chatService.setActiveSession(sessionId, { focus: true });
-    };
-
-    protected handleBrowseAllChats = (): void => {
-        this.commandRegistry.executeCommand(AI_CHAT_SHOW_CHATS_COMMAND.id);
     };
 }

--- a/packages/ai-ide/src/browser/chat-session-list-components.tsx
+++ b/packages/ai-ide/src/browser/chat-session-list-components.tsx
@@ -14,10 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ChatSessionMetadata } from '@theia/ai-chat';
-import { buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
+import { ChatAgentService, ChatService, ChatSessionMetadata } from '@theia/ai-chat';
+import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
+import { buttonKeyboardProps, HoverService, isActivationKey } from '@theia/core/lib/browser';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { CommandRegistry, ContributionProvider } from '@theia/core';
 import { nls } from '@theia/core/lib/common/nls';
 import * as React from '@theia/core/shared/react';
+import { ChatSessionItemAction, ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
+import { ChatSessionItem, UnreadStateProvider } from './chat-session-item';
 
 /** When both Active and Restored sections are non-empty, keep at least this many Restored slots. */
 const RESTORED_MIN_RESERVATION = 5;
@@ -61,6 +66,50 @@ export interface SessionsListProps {
     maxSessions: number;
     renderItem: (session: ChatSessionMetadata, isRestored: boolean) => React.ReactNode;
     onBrowseAll: () => void;
+}
+
+export interface SessionItemHandlerDeps {
+    chatService: ChatService;
+    chatAgentService: ChatAgentService;
+    hoverService: HoverService;
+    markdownRenderer: MarkdownRenderer;
+    commandRegistry: CommandRegistry;
+    unreadState: UnreadStateProvider;
+    chatSessionItemActionContributions: ContributionProvider<ChatSessionItemActionContribution>;
+}
+
+export function createSessionItemRenderer(deps: SessionItemHandlerDeps): {
+    renderSessionItem: (session: ChatSessionMetadata, isRestored: boolean) => React.ReactNode;
+} {
+    const renderSessionItem = (session: ChatSessionMetadata, isRestored: boolean): React.ReactNode => {
+        const actions = deps.chatSessionItemActionContributions
+            .getContributions()
+            .flatMap(c => c.getActions(session))
+            .filter(action => deps.commandRegistry.isEnabled(action.commandId, session))
+            .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+        return (
+            <ChatSessionItem
+                key={session.sessionId}
+                session={session}
+                isRestored={isRestored}
+                chatService={deps.chatService}
+                chatAgentService={deps.chatAgentService}
+                hoverService={deps.hoverService}
+                markdownRenderer={deps.markdownRenderer}
+                unreadState={deps.unreadState}
+                onClick={async () => {
+                    await deps.chatService.getOrRestoreSession(session.sessionId);
+                    deps.chatService.setActiveSession(session.sessionId, { focus: true });
+                }}
+                actions={actions}
+                onAction={(action: ChatSessionItemAction, s: ChatSessionMetadata) => {
+                    deps.commandRegistry.executeCommand(action.commandId, s);
+                }}
+                formatTimeAgo={date => formatTimeAgo(date)}
+            />
+        );
+    };
+    return { renderSessionItem };
 }
 
 export function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: SessionsListProps): React.ReactElement {

--- a/packages/ai-ide/src/browser/chat-session-list-components.tsx
+++ b/packages/ai-ide/src/browser/chat-session-list-components.tsx
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { ChatAgentService, ChatService, ChatSessionMetadata } from '@theia/ai-chat';
+import { AI_CHAT_OPEN_SESSION } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
 import { buttonKeyboardProps, HoverService, isActivationKey } from '@theia/core/lib/browser';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
@@ -98,8 +99,7 @@ export function createSessionItemRenderer(deps: SessionItemHandlerDeps): {
                 markdownRenderer={deps.markdownRenderer}
                 unreadState={deps.unreadState}
                 onClick={async () => {
-                    await deps.chatService.getOrRestoreSession(session.sessionId);
-                    deps.chatService.setActiveSession(session.sessionId, { focus: true });
+                    await deps.commandRegistry.executeCommand(AI_CHAT_OPEN_SESSION.id, session.sessionId);
                 }}
                 actions={actions}
                 onAction={(action: ChatSessionItemAction, s: ChatSessionMetadata) => {

--- a/packages/ai-ide/src/browser/chat-session-list-components.tsx
+++ b/packages/ai-ide/src/browser/chat-session-list-components.tsx
@@ -1,0 +1,108 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatSessionMetadata } from '@theia/ai-chat';
+import { buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/common/nls';
+import * as React from '@theia/core/shared/react';
+
+/** When both Active and Restored sections are non-empty, keep at least this many Restored slots. */
+const RESTORED_MIN_RESERVATION = 5;
+
+export interface SectionedSessions {
+    active: ChatSessionMetadata[];
+    restored: ChatSessionMetadata[];
+}
+
+export interface VisibleSessionSlots {
+    activeCount: number;
+    restoredCount: number;
+}
+
+/**
+ * Allocates the capped number of visible items between the Active and Restored sections of the
+ * overview. When both sections are non-empty, up to {@link RESTORED_MIN_RESERVATION} slots are
+ * reserved for Restored so active sessions cannot crowd it out entirely. A cap of 0 hides the
+ * inline list (every session stays reachable via the "Browse all chats..." link).
+ */
+export function computeVisibleSessionSlots(activeTotal: number, restoredTotal: number, maxSessions: number): VisibleSessionSlots {
+    const cap = Math.max(0, maxSessions);
+    if (cap === 0) {
+        return { activeCount: 0, restoredCount: 0 };
+    }
+    if (restoredTotal === 0) {
+        return { activeCount: Math.min(activeTotal, cap), restoredCount: 0 };
+    }
+    if (activeTotal === 0) {
+        return { activeCount: 0, restoredCount: Math.min(restoredTotal, cap) };
+    }
+    const reserved = Math.min(restoredTotal, Math.min(RESTORED_MIN_RESERVATION, Math.max(1, cap - 1)));
+    const activeCount = Math.min(activeTotal, cap - reserved);
+    const restoredCount = Math.min(restoredTotal, cap - activeCount);
+    return { activeCount, restoredCount };
+}
+
+export interface SessionsListProps {
+    sections: SectionedSessions;
+    /** Total cap on items shown; overflow surfaces via the Browse all link. */
+    maxSessions: number;
+    renderItem: (session: ChatSessionMetadata, isRestored: boolean) => React.ReactNode;
+    onBrowseAll: () => void;
+}
+
+export function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: SessionsListProps): React.ReactElement {
+    const total = sections.active.length + sections.restored.length;
+    const { activeCount, restoredCount } = computeVisibleSessionSlots(sections.active.length, sections.restored.length, maxSessions);
+    const activeVisible = sections.active.slice(0, activeCount);
+    const restoredVisible = sections.restored.slice(0, restoredCount);
+    const hiddenCount = total - activeVisible.length - restoredVisible.length;
+
+    return (
+        <div className="theia-WelcomeMessage-SessionsList">
+            {activeVisible.length > 0 && (
+                <div className="theia-WelcomeMessage-SessionsGroup">
+                    <div className="theia-WelcomeMessage-SessionsHeader">
+                        {nls.localizeByDefault('Active')}
+                    </div>
+                    {activeVisible.map(s => renderItem(s, false))}
+                </div>
+            )}
+            {restoredVisible.length > 0 && (
+                <div className="theia-WelcomeMessage-SessionsGroup">
+                    <div className="theia-WelcomeMessage-SessionsHeader">
+                        {nls.localize('theia/ai/ide/sectionRestored', 'Restored')}
+                    </div>
+                    {restoredVisible.map(s => renderItem(s, true))}
+                </div>
+            )}
+            {hiddenCount > 0 && (
+                <div className="theia-WelcomeMessage-SessionsFooter">
+                    <a className="theia-WelcomeMessage-FooterLink"
+                        {...buttonKeyboardProps(nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...'))}
+                        onClick={onBrowseAll}
+                        onKeyDown={e => {
+                            if (isActivationKey(e)) {
+                                e.preventDefault();
+                                onBrowseAll();
+                            }
+                        }}>
+                        {nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...')}
+                    </a>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ai-ide/src/browser/chat-session-list-service.ts
+++ b/packages/ai-ide/src/browser/chat-session-list-service.ts
@@ -1,0 +1,186 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatService, ChatSession, ChatSessionMetadata } from '@theia/ai-chat';
+import { PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { DisposableCollection, Emitter, Event, PreferenceService } from '@theia/core';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { UnreadStateProvider } from './chat-session-item';
+import { SectionedSessions } from './chat-session-list-components';
+
+@injectable()
+export class ChatSessionListService implements UnreadStateProvider {
+
+    @inject(ChatService)
+    protected readonly chatService: ChatService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    private readonly unreadSessions = new Map<string, { unread: boolean; seenRequests: number; seenCompleted: number; listener: DisposableCollection }>();
+    private readonly onUnreadChangedEmitter = new Emitter<string>();
+    readonly onUnreadChanged: Event<string> = this.onUnreadChangedEmitter.event;
+
+    protected _persistedSessions: ChatSessionMetadata[] = [];
+
+    protected readonly onStateChangedEmitter = new Emitter<void>();
+    readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        for (const session of this.chatService.getSessions()) {
+            this.watchSession(session);
+        }
+
+        this.chatService.onSessionEvent(event => {
+            if (event.type === 'created') {
+                const s = this.chatService.getSession(event.sessionId);
+                if (s) {
+                    this.watchSession(s);
+                }
+            } else if (event.type === 'activeChange' && event.sessionId) {
+                this.markSessionRead(event.sessionId);
+            } else if (event.type === 'deleted') {
+                this.unwatchSession(event.sessionId);
+            }
+            this.loadSessions();
+        });
+
+        this.loadSessions();
+        this.preferenceService.onPreferenceChanged(e => {
+            if (e.preferenceName === PERSISTED_SESSION_LIMIT_PREF || e.preferenceName === SESSION_STORAGE_PREF) {
+                this.loadSessions();
+            }
+        });
+    }
+
+    isUnread(sessionId: string): boolean {
+        return this.unreadSessions.get(sessionId)?.unread === true;
+    }
+
+    protected watchSession(session: ChatSession): void {
+        if (this.unreadSessions.has(session.id)) {
+            return;
+        }
+        const reqs = session.model.getRequests();
+        const state = {
+            unread: false,
+            seenRequests: reqs.length,
+            seenCompleted: this.countCompleted(reqs),
+            listener: new DisposableCollection()
+        };
+        this.unreadSessions.set(session.id, state);
+
+        session.model.onDidChange(() => {
+            const current = session.model.getRequests();
+            if (current.length > state.seenRequests || this.countCompleted(current) > state.seenCompleted) {
+                const activeSession = this.chatService.getActiveSession();
+                const chatViewFocused = ChatViewWidget.findActive(this.shell) !== undefined;
+                if (chatViewFocused && activeSession && activeSession.id === session.id) {
+                    state.seenRequests = current.length;
+                    state.seenCompleted = this.countCompleted(current);
+                } else if (!state.unread) {
+                    state.unread = true;
+                    this.onUnreadChangedEmitter.fire(session.id);
+                }
+            }
+        }, undefined, state.listener);
+    }
+
+    protected markSessionRead(sessionId: string): void {
+        const state = this.unreadSessions.get(sessionId);
+        if (!state) {
+            return;
+        }
+        const session = this.chatService.getSession(sessionId);
+        const reqs = session?.model.getRequests() ?? [];
+        state.seenRequests = reqs.length;
+        state.seenCompleted = this.countCompleted(reqs);
+        if (state.unread) {
+            state.unread = false;
+            this.onUnreadChangedEmitter.fire(sessionId);
+        }
+    }
+
+    protected unwatchSession(sessionId: string): void {
+        const state = this.unreadSessions.get(sessionId);
+        if (state) {
+            state.listener.dispose();
+            this.unreadSessions.delete(sessionId);
+        }
+    }
+
+    private countCompleted(reqs: ReturnType<ChatSession['model']['getRequests']>): number {
+        return reqs.filter(r => r.response.isComplete).length;
+    }
+
+    isPersistenceEnabled(): boolean {
+        const limit = this.preferenceService.get<number>(PERSISTED_SESSION_LIMIT_PREF, 25);
+        return limit !== 0;
+    }
+
+    protected async loadSessions(): Promise<void> {
+        if (!this.isPersistenceEnabled()) {
+            this._persistedSessions = [];
+            this.onStateChangedEmitter.fire();
+            return;
+        }
+
+        const hasSessions = await this.chatService.hasPersistedSessions();
+        if (!hasSessions) {
+            this._persistedSessions = [];
+            this.onStateChangedEmitter.fire();
+            return;
+        }
+
+        try {
+            const index = await this.chatService.getPersistedSessions();
+            this._persistedSessions = Object.values(index)
+                .toSorted((a, b) => b.saveDate - a.saveDate);
+        } catch (error) {
+            console.error('Failed to load persisted sessions:', error);
+            this._persistedSessions = [];
+        } finally {
+            this.onStateChangedEmitter.fire();
+        }
+    }
+
+    getSections(): SectionedSessions {
+        const activeRaw = this.chatService.getSessions().filter(s => !!s.title);
+        const activeIds = new Set(activeRaw.map(s => s.id));
+        const active: ChatSessionMetadata[] = activeRaw
+            .toSorted((a, b) => (b.lastInteraction?.getTime() ?? 0) - (a.lastInteraction?.getTime() ?? 0))
+            .map(session => {
+                const lastReq = session.model.getRequests().at(-1);
+                const hasError = lastReq?.response.isComplete === true && lastReq?.response.isError === true;
+                return {
+                    sessionId: session.id,
+                    title: session.title!,
+                    saveDate: session.lastInteraction?.getTime() ?? Date.now(),
+                    location: session.model.location,
+                    pinnedAgentId: session.pinnedAgent?.id,
+                    hasError
+                };
+            });
+        const restored = this._persistedSessions.filter(metadata => !activeIds.has(metadata.sessionId));
+        return { active, restored };
+    }
+}

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
@@ -23,7 +23,8 @@ import { Emitter } from '@theia/core';
 import { ChatAgentLocation, ChatService, ChatSession, ChatSessionMetadata } from '@theia/ai-chat';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { ApplicationShell, Widget } from '@theia/core/lib/browser';
-import { ChatSessionsWelcomeMessageProvider, SectionedSessions, computeVisibleSessionSlots } from './chat-sessions-welcome-message-provider';
+import { ChatSessionListService } from './chat-session-list-service';
+import { SectionedSessions, computeVisibleSessionSlots } from './chat-session-list-components';
 disableJSDOM();
 
 /**
@@ -32,7 +33,7 @@ disableJSDOM();
  * unread bookkeeping; spinning up the full container would pull in unrelated
  * services and obscure the assertion.
  */
-class TestableProvider extends ChatSessionsWelcomeMessageProvider {
+class TestableService extends ChatSessionListService {
     constructor(chatService: ChatService, shell: ApplicationShell) {
         super();
         (this as unknown as { chatService: ChatService }).chatService = chatService;
@@ -70,7 +71,7 @@ function createFakeSession(id: string): {
     };
 }
 
-describe('ChatSessionsWelcomeMessageProvider', () => {
+describe('ChatSessionListService', () => {
 
     describe('unread state', () => {
         let activeSessionId: string | undefined;
@@ -112,33 +113,33 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         });
 
         it('marks the session unread when a new request arrives and the chat view is not focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             activeWidget = otherWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
         });
 
         it('does not mark unread when the session is active AND the chat view is focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             activeWidget = chatViewWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(false);
+            expect(service.isUnread('s1')).to.equal(false);
         });
 
         it('does not mark unread when focus is inside a child widget of the chat view', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             // Simulate focus inside a descendant (e.g. AIChatInputWidget): the shell's
@@ -147,42 +148,42 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
             activeWidget = childWidget;
             widgetForActiveElement = childWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(false);
+            expect(service.isUnread('s1')).to.equal(false);
         });
 
         it('marks unread when the session is not the active one, even if the chat view is focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 'other';
             activeWidget = chatViewWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
         });
 
         it('fires onUnreadChanged once when a session transitions to unread', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = undefined;
             activeWidget = otherWidget;
 
             let fired = 0;
-            provider.onUnreadChanged(() => { fired++; });
+            service.onUnreadChanged(() => { fired++; });
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
             expect(fired).to.equal(1);
         });
     });
@@ -239,11 +240,11 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
 
     describe('getSections', () => {
 
-        class SectionsTestProvider extends ChatSessionsWelcomeMessageProvider {
+        class SectionsTestService extends ChatSessionListService {
             constructor(sessions: ChatSession[], persistedSessions: ChatSessionMetadata[]) {
                 super();
                 (this as unknown as { chatService: ChatService }).chatService = { getSessions: () => sessions } as unknown as ChatService;
-                this._persistedSessions = persistedSessions;
+                (this as unknown as { _persistedSessions: ChatSessionMetadata[] })._persistedSessions = persistedSessions;
             }
             sections(): SectionedSessions {
                 return this.getSections();
@@ -275,7 +276,7 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         }
 
         function getSections(sessions: ChatSession[], persistedSessions: ChatSessionMetadata[]): SectionedSessions {
-            return new SectionsTestProvider(sessions, persistedSessions).sections();
+            return new SectionsTestService(sessions, persistedSessions).sections();
         }
 
         it('excludes active sessions without a title', () => {

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -15,16 +15,14 @@
 // *****************************************************************************
 
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
-import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
 import {
-    ChatAgentService, ChatService, ChatSessionMetadata
+    ChatAgentService, ChatService
 } from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
-import { ChatSessionItemAction, ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
-import { ChatSessionItem } from './chat-session-item';
+import { ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
 import { ChatSessionListService } from './chat-session-list-service';
-import { SectionedSessions, SessionsList } from './chat-session-list-components';
+import { createSessionItemRenderer, SectionedSessions, SessionsList } from './chat-session-list-components';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { CommandRegistry, ContributionProvider, Emitter, Event, PreferenceService } from '@theia/core';
 import { HoverService } from '@theia/core/lib/browser';
@@ -72,6 +70,22 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
             this._markdownRenderer = this.markdownRendererFactory();
         }
         return this._markdownRenderer;
+    }
+
+    protected sessionItemRenderer: ReturnType<typeof createSessionItemRenderer> | undefined;
+    protected getSessionItemRenderer(): ReturnType<typeof createSessionItemRenderer> {
+        if (!this.sessionItemRenderer) {
+            this.sessionItemRenderer = createSessionItemRenderer({
+                chatService: this.chatService,
+                chatAgentService: this.chatAgentService,
+                hoverService: this.hoverService,
+                markdownRenderer: this.markdownRenderer,
+                commandRegistry: this.commandRegistry,
+                unreadState: this.sessionListService,
+                chatSessionItemActionContributions: this.chatSessionItemActionContributions
+            });
+        }
+        return this.sessionItemRenderer;
     }
 
     protected readonly onStateChangedEmitter = new Emitter<void>();
@@ -127,46 +141,13 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                     <SessionsList
                         sections={sections}
                         maxSessions={maxSessions}
-                        renderItem={this.renderSessionItem}
+                        renderItem={this.getSessionItemRenderer().renderSessionItem}
                         onBrowseAll={this.handleBrowseAllChats}
                     />
                 </div>
             </div>
         );
     }
-
-    protected renderSessionItem = (session: ChatSessionMetadata, isRestored: boolean): React.ReactNode => {
-        const actions = this.chatSessionItemActionContributions
-            .getContributions()
-            .flatMap(c => c.getActions(session))
-            .filter(action => this.commandRegistry.isEnabled(action.commandId, session))
-            .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
-        return (
-            <ChatSessionItem
-                key={session.sessionId}
-                session={session}
-                isRestored={isRestored}
-                chatService={this.chatService}
-                chatAgentService={this.chatAgentService}
-                hoverService={this.hoverService}
-                markdownRenderer={this.markdownRenderer}
-                unreadState={this.sessionListService}
-                onClick={() => this.handleSessionItemClick(session.sessionId)}
-                actions={actions}
-                onAction={this.handleSessionItemAction}
-                formatTimeAgo={date => formatTimeAgo(date)}
-            />
-        );
-    };
-
-    protected handleSessionItemAction = (action: ChatSessionItemAction, session: ChatSessionMetadata): void => {
-        this.commandRegistry.executeCommand(action.commandId, session);
-    };
-
-    protected handleSessionItemClick = async (sessionId: string): Promise<void> => {
-        await this.chatService.getOrRestoreSession(sessionId);
-        this.chatService.setActiveSession(sessionId, { focus: true });
-    };
 
     protected handleBrowseAllChats = (): void => {
         this.commandRegistry.executeCommand(AI_CHAT_SHOW_CHATS_COMMAND.id);

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -127,6 +127,9 @@ import { PRReviewAgent } from './review/pr-review-agent';
 import { PRReviewCapabilityContribution } from './review/pr-review-capability-contribution';
 import { PerspectiveContribution } from '@theia/core/lib/browser/perspective-service';
 import { AIFirstPerspectiveContribution } from './ai-first-perspective-contribution';
+import { ChatSessionListService } from './chat-session-list-service';
+import { AISessionsWidget } from './ai-sessions-widget';
+import { AISessionsViewContribution } from './ai-sessions-view-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -193,6 +196,8 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PRReviewAgent).toSelf().inSingletonScope();
     bind(Agent).toService(PRReviewAgent);
     bind(ChatAgent).toService(PRReviewAgent);
+
+    bind(ChatSessionListService).toSelf().inSingletonScope();
 
     bind(ChatWelcomeMessageProvider).to(IdeChatWelcomeMessageProvider).inSingletonScope();
     bind(ChatWelcomeMessageProvider).to(ChatSessionsWelcomeMessageProvider).inSingletonScope();
@@ -355,4 +360,13 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(AIFirstPerspectiveContribution).toSelf().inSingletonScope();
     bind(PerspectiveContribution).toService(AIFirstPerspectiveContribution);
+
+    bind(AISessionsWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: AISessionsWidget.ID,
+            createWidget: () => ctx.container.get(AISessionsWidget)
+        }))
+        .inSingletonScope();
+    bindViewContribution(bind, AISessionsViewContribution);
 });

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -369,4 +369,5 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         }))
         .inSingletonScope();
     bindViewContribution(bind, AISessionsViewContribution);
+    bind(TabBarToolbarContribution).toService(AISessionsViewContribution);
 });

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -2170,3 +2170,31 @@
   outline: 2px solid var(--theia-focusBorder);
   outline-offset: -2px;
 }
+
+/* AI Sessions View */
+.ai-sessions-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.ai-sessions-view-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--theia-ui-padding) 0;
+}
+
+.ai-sessions-view-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--theia-descriptionForeground);
+  gap: var(--theia-ui-padding);
+}
+
+.ai-sessions-view-empty .codicon {
+  font-size: calc(var(--theia-ui-font-size1) * 2.5);
+  opacity: 0.5;
+}

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -155,8 +155,8 @@ export class HoverService {
         }
         // browsers might insert linebreaks when the hover appears at the edge of the window
         // resetting the position prevents that
-        host.style.left = '0px';
-        host.style.top = '0px';
+        host.style.left = '-9999px';
+        host.style.top = '-9999px';
         document.body.append(host);
         if (!host.matches(':popover-open')) {
             host.showPopover();

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -361,4 +361,3 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
         }
     }
 }
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Add a new "AI Sessions" view listing the current sessions from the Chat Service
- The UI is extracted from the Welcome Message Provider in AI Chat
- Hide the Home button in AI Chat and add New Session in AI Sessions when using the AI First perspective

<img width="1021" height="628" alt="image" src="https://github.com/user-attachments/assets/b4472518-6a13-4031-8d72-6f9a7aa0906b" />


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Switch to the AI First perspective (Note: if the perspective was already persisted prior to this PR, the AI Sessions view may need to be opened manually)
- AI Sessions and AI Chat should be open side by side
- AI Sessions shows existing sessions, can navigate them, and create new sessions

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
