### PR TITLE
feat(ai-ide): render delegated sessions as children in session list

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -448,7 +448,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
     protected async askForChatSession(): Promise<QuickPickItem | undefined> {
         const getItems = async (): Promise<(QuickPickItem | QuickPickSeparator)[]> => {
             const activeSessions = this.chatService.getSessions()
-                .filter(session => session.title)
+                .filter(session => session.title && !session.rootSessionId)
                 .map(session => ({
                     isActive: true as const,
                     id: session.id,
@@ -475,7 +475,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                 const persistedIndex = await this.chatService.getPersistedSessions();
                 const activeIds = new Set(activeSessions.map(s => s.id));
                 persistedSessions = Object.values(persistedIndex)
-                    .filter(metadata => !activeIds.has(metadata.sessionId))
+                    .filter(metadata => !activeIds.has(metadata.sessionId) && !metadata.rootSessionId)
                     .map(metadata => {
                         const agent = metadata.pinnedAgentId ? this.chatAgentService.getAgent(metadata.pinnedAgentId) : undefined;
                         return {

--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -248,4 +248,20 @@ describe('AgentDelegationTool', () => {
             expect(result).to.equal('');
         });
     });
+
+    describe('delegateToAgent() — session persistence', () => {
+        it('does not delete the delegated session after completion', async () => {
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            await tool.getTool().handler(argString, ctx);
+
+            // deleteSession should never have been called for the delegated session
+            expect((chatService.deleteSession as sinon.SinonStub).called).to.be.false;
+        });
+    });
 });

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -124,8 +124,6 @@ export class AgentDelegationTool implements ToolProvider {
             let newSession;
             let childModelDisposable: Disposable | undefined;
             try {
-                // FIXME: this creates a new conversation visible in the UI (Panel), which we don't want
-                // It is not possible to start a session without specifying a location (default=Panel)
                 const chatService = this.getChatService();
 
                 // Store the current active session to restore it after delegation
@@ -222,12 +220,8 @@ export class AgentDelegationTool implements ToolProvider {
                         .filter((text): text is string => text !== undefined && text !== '')
                         .join('\n\n');
 
-                    // Clean up the session and parent-child link after completion
+                    // Clean up the parent-child link after completion (event bubbling is no longer needed)
                     childModelDisposable?.dispose();
-                    const chatService = this.getChatService();
-                    chatService.deleteSession(newSession.id).catch(error => {
-                        this.logger.error('Failed to delete delegated session', error);
-                    });
 
                     // Return the raw text to the top-level Agent, as a tool result
                     return stringResult;

--- a/packages/ai-chat/src/browser/chat-session-store-impl.spec.ts
+++ b/packages/ai-chat/src/browser/chat-session-store-impl.spec.ts
@@ -63,12 +63,13 @@ describe('ChatSessionStoreImpl', () => {
     const GLOBAL_CONFIG_DIR = 'file:///__test__/mock-config';
     const DEFAULT_STORAGE_SCOPE: SessionStorageScope = 'workspace';
 
-    function createMockSessionMetadata(id: string, saveDate: number): ChatSessionMetadata {
+    function createMockSessionMetadata(id: string, saveDate: number, rootSessionId?: string): ChatSessionMetadata {
         return {
             sessionId: id,
             title: `Session ${id}`,
             saveDate,
-            location: ChatAgentLocation.Panel
+            location: ChatAgentLocation.Panel,
+            rootSessionId
         };
     }
 
@@ -699,6 +700,65 @@ describe('ChatSessionStoreImpl', () => {
 
             // readFile should have been called twice
             expect(mockFileService.readFile.callCount).to.equal(2);
+        });
+    });
+
+    describe('rootSessionId persistence', () => {
+        const mockModel = (id: string) => ({
+            id,
+            isEmpty: () => false,
+            location: ChatAgentLocation.Panel,
+            toSerializable: () => ({
+                location: ChatAgentLocation.Panel,
+                requests: [],
+                responses: [],
+                hierarchy: { rootBranchId: '', branches: {} }
+            })
+        });
+
+        it('should include rootSessionId in the session index when updating', async () => {
+            mockPreferenceService.get.withArgs(PERSISTED_SESSION_LIMIT_PREF, 25).returns(25);
+
+            const sessions = [
+                { model: mockModel('parent-session') as never, title: 'Parent Session', saveDate: 1000, pinnedAgentId: undefined, rootSessionId: undefined },
+                { model: mockModel('child-session') as never, title: 'Child Session', saveDate: 2000, pinnedAgentId: undefined, rootSessionId: 'parent-session' }
+            ] as never[];
+
+            // Setup index file response
+            const index = { 'parent-session': { sessionId: 'parent-session', title: 'Parent Session', saveDate: 1000, location: 'panel' } };
+            mockFileService.readFile.resolves({
+                value: BinaryBuffer.fromString(JSON.stringify(index))
+            } as never);
+
+            // Access protected method via any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (chatSessionStore as any).updateIndex(sessions);
+
+            const savedIndexCall = mockFileService.writeFile.lastCall;
+            const savedIndex = JSON.parse(savedIndexCall.args[1].toString());
+            expect(savedIndex['child-session']).to.not.be.undefined;
+            expect(savedIndex['child-session'].rootSessionId).to.equal('parent-session');
+        });
+
+        it('should handle sessions without rootSessionId', async () => {
+            mockPreferenceService.get.withArgs(PERSISTED_SESSION_LIMIT_PREF, 25).returns(25);
+
+            const sessions = [
+                { model: mockModel('standalone-session') as never, title: 'Standalone Session', saveDate: 1000, pinnedAgentId: undefined, rootSessionId: undefined }
+            ] as never[];
+
+            const index = { 'standalone-session': { sessionId: 'standalone-session', title: 'Standalone Session', saveDate: 1000, location: 'panel' } };
+            mockFileService.readFile.resolves({
+                value: BinaryBuffer.fromString(JSON.stringify(index))
+            } as never);
+
+            // Access protected method via any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (chatSessionStore as any).updateIndex(sessions);
+
+            const savedIndexCall = mockFileService.writeFile.lastCall;
+            const savedIndex = JSON.parse(savedIndexCall.args[1].toString());
+            expect(savedIndex['standalone-session'].rootSessionId).to.be.undefined;
         });
     });
 

--- a/packages/ai-chat/src/browser/chat-session-store-impl.ts
+++ b/packages/ai-chat/src/browser/chat-session-store-impl.ts
@@ -116,6 +116,7 @@ export class ChatSessionStoreImpl implements ChatSessionStore {
                     title: session.title,
                     pinnedAgentId: session.pinnedAgentId,
                     saveDate: session.saveDate,
+                    rootSessionId: session.rootSessionId,
                     model: modelData
                 };
                 this.logger.debug('Writing session to file', {

--- a/packages/ai-chat/src/common/chat-model-serialization.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.ts
@@ -201,6 +201,8 @@ export interface SerializedChatData {
     title?: string;
     model: SerializedChatModel;
     saveDate: number;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
 }
 
 export interface SerializableChatsData {

--- a/packages/ai-chat/src/common/chat-service.spec.ts
+++ b/packages/ai-chat/src/common/chat-service.spec.ts
@@ -1,0 +1,211 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Container } from '@theia/core/shared/inversify';
+import { ChatServiceImpl } from './chat-service';
+import { ChatAgentService } from './chat-agent-service';
+import { ChatSessionStore } from './chat-session-store';
+import { ChatContentDeserializerRegistry } from './chat-content-deserializer';
+import { ChangeSetElementDeserializerRegistry } from './change-set-element-deserializer';
+import { ToolInvocationRegistry, AIVariableService } from '@theia/ai-core';
+import { ILogger } from '@theia/core';
+import { ChatRequestParser } from './chat-request-parser';
+
+disableJSDOM();
+
+describe('ChatServiceImpl', () => {
+    let sandbox: sinon.SinonSandbox;
+    let chatService: ChatServiceImpl;
+    let mockSessionStore: sinon.SinonStubbedInstance<ChatSessionStore>;
+    let mockAgentService: sinon.SinonStubbedInstance<ChatAgentService>;
+    let mockDeserRegistry: sinon.SinonStubbedInstance<ChatContentDeserializerRegistry>;
+    let mockChangeSetDeserRegistry: sinon.SinonStubbedInstance<ChangeSetElementDeserializerRegistry>;
+    let mockToolInvocationRegistry: sinon.SinonStubbedInstance<ToolInvocationRegistry>;
+    let mockVariableService: sinon.SinonStubbedInstance<AIVariableService>;
+    let mockRequestParser: sinon.SinonStubbedInstance<ChatRequestParser>;
+    let mockLogger: sinon.SinonStubbedInstance<ILogger>;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        mockSessionStore = {
+            storeSessions: sandbox.stub().resolves(),
+            readSession: sandbox.stub().resolves(undefined) as never,
+            deleteSession: sandbox.stub().resolves() as never,
+            clearAllSessions: sandbox.stub().resolves() as never,
+            getSessionIndex: sandbox.stub().resolves({}) as never,
+            hasPersistedSessions: sandbox.stub().resolves(false) as never
+        };
+
+        mockAgentService = {
+            getAgent: sandbox.stub().returns(undefined),
+            getAgents: sandbox.stub().returns([]),
+            resolveAgent: sandbox.stub().returns(undefined)
+        } as sinon.SinonStubbedInstance<ChatAgentService>;
+
+        mockDeserRegistry = {
+            deserialize: sandbox.stub().resolves([])
+        } as sinon.SinonStubbedInstance<ChatContentDeserializerRegistry>;
+
+        mockChangeSetDeserRegistry = {
+            deserialize: sandbox.stub().resolves([])
+        } as sinon.SinonStubbedInstance<ChangeSetElementDeserializerRegistry>;
+
+        mockToolInvocationRegistry = {
+            getFunction: sandbox.stub().returns(undefined)
+        } as sinon.SinonStubbedInstance<ToolInvocationRegistry>;
+
+        mockVariableService = {
+            resolveVariable: sandbox.stub().resolves(undefined)
+        } as sinon.SinonStubbedInstance<AIVariableService>;
+
+        mockRequestParser = {
+            parseChatRequest: sandbox.stub().resolves({ parts: [], toolRequests: [], variables: [] })
+        } as sinon.SinonStubbedInstance<ChatRequestParser>;
+
+        mockLogger = {
+            debug: sandbox.stub(),
+            info: sandbox.stub(),
+            warn: sandbox.stub(),
+            error: sandbox.stub()
+        } as sinon.SinonStubbedInstance<ILogger>;
+
+        const container = new Container();
+        container.bind(ChatServiceImpl).toSelf().inSingletonScope();
+        container.bind(ChatAgentService).toConstantValue(mockAgentService);
+        container.bind(ChatSessionStore).toConstantValue(mockSessionStore);
+        container.bind(ChatContentDeserializerRegistry).toConstantValue(mockDeserRegistry);
+        container.bind(ChangeSetElementDeserializerRegistry).toConstantValue(mockChangeSetDeserRegistry);
+        container.bind(ToolInvocationRegistry).toConstantValue(mockToolInvocationRegistry);
+        container.bind(ChatRequestParser).toConstantValue(mockRequestParser);
+        container.bind(AIVariableService).toConstantValue(mockVariableService);
+        container.bind(ILogger).toConstantValue(mockLogger);
+
+        chatService = container.get(ChatServiceImpl);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('deleteSession', () => {
+        it('should delete child sessions when deleting a parent session', async () => {
+            // Create a parent session
+            const parentSession = chatService.createSession();
+
+            // Create a child session by directly setting rootSessionId
+            const childSession = chatService.createSession();
+            childSession.rootSessionId = parentSession.id;
+
+            // Delete the parent session
+            await chatService.deleteSession(parentSession.id);
+
+            // Verify parent session was deleted
+            expect(chatService.getSession(parentSession.id)).to.be.undefined;
+
+            // Verify child session was also deleted (cascade delete)
+            expect(chatService.getSession(childSession.id)).to.be.undefined;
+
+            // Verify deleteSession was called for both sessions
+            expect(mockSessionStore.deleteSession.callCount).to.equal(2);
+            expect(mockSessionStore.deleteSession.calledWith(parentSession.id)).to.be.true;
+            expect(mockSessionStore.deleteSession.calledWith(childSession.id)).to.be.true;
+        });
+
+        it('should handle multiple child sessions', async () => {
+            // Create a parent session
+            const parentSession = chatService.createSession();
+
+            // Create multiple child sessions
+            const child1 = chatService.createSession();
+            child1.rootSessionId = parentSession.id;
+            const child2 = chatService.createSession();
+            child2.rootSessionId = parentSession.id;
+            const child3 = chatService.createSession();
+            child3.rootSessionId = parentSession.id;
+
+            // Delete the parent session
+            await chatService.deleteSession(parentSession.id);
+
+            // Verify all sessions were deleted
+            expect(chatService.getSession(parentSession.id)).to.be.undefined;
+            expect(chatService.getSession(child1.id)).to.be.undefined;
+            expect(chatService.getSession(child2.id)).to.be.undefined;
+            expect(chatService.getSession(child3.id)).to.be.undefined;
+
+            // Verify deleteSession was called for all sessions
+            expect(mockSessionStore.deleteSession.callCount).to.equal(4);
+        });
+
+        it('should not delete sessions without rootSessionId', async () => {
+            // Create a standalone session
+            const standaloneSession = chatService.createSession();
+
+            // Delete it
+            await chatService.deleteSession(standaloneSession.id);
+
+            // Verify only that session was deleted
+            expect(chatService.getSession(standaloneSession.id)).to.be.undefined;
+            expect(mockSessionStore.deleteSession.callCount).to.equal(1);
+        });
+
+        it('should delete persisted-only child sessions that are not loaded in memory', async () => {
+            // Parent is in memory; the child exists only in the persisted index (e.g. after a reload).
+            const parentSession = chatService.createSession();
+            const persistedChildId = 'persisted-child-id';
+            mockSessionStore.getSessionIndex.resolves({
+                [persistedChildId]: {
+                    sessionId: persistedChildId,
+                    title: 'Persisted child',
+                    saveDate: 0,
+                    location: parentSession.model.location,
+                    rootSessionId: parentSession.id
+                }
+            });
+
+            await chatService.deleteSession(parentSession.id);
+
+            // Both the in-memory parent and the persisted-only child are removed from storage.
+            expect(mockSessionStore.deleteSession.calledWith(parentSession.id)).to.be.true;
+            expect(mockSessionStore.deleteSession.calledWith(persistedChildId)).to.be.true;
+        });
+
+        it('should not delete sessions with different rootSessionId', async () => {
+            // Create two independent sessions
+            const session1 = chatService.createSession();
+            const session2 = chatService.createSession();
+
+            // Set session2 as a child of a non-existent session
+            session2.rootSessionId = 'non-existent-session-id';
+
+            // Delete session1
+            await chatService.deleteSession(session1.id);
+
+            // Verify only session1 was deleted
+            expect(chatService.getSession(session1.id)).to.be.undefined;
+            expect(chatService.getSession(session2.id)).to.not.be.undefined;
+            expect(mockSessionStore.deleteSession.callCount).to.equal(1);
+            expect(mockSessionStore.deleteSession.calledWith(session1.id)).to.be.true;
+        });
+    });
+});

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -224,6 +224,31 @@ export class ChatServiceImpl implements ChatService {
     }
 
     async deleteSession(sessionId: string): Promise<void> {
+        // Delete children (sessions whose rootSessionId points to this session) first. Children may
+        // live only in memory, only in persisted storage (e.g. after a reload, not yet restored),
+        // or both, so collect ids from both sources to avoid orphaning persisted-only children.
+        const childIds = new Set<string>();
+        for (const s of this._sessions) {
+            if (s.rootSessionId === sessionId) {
+                childIds.add(s.id);
+            }
+        }
+        if (this.sessionStore) {
+            try {
+                const index = await this.sessionStore.getSessionIndex();
+                for (const metadata of Object.values(index)) {
+                    if (metadata.rootSessionId === sessionId) {
+                        childIds.add(metadata.sessionId);
+                    }
+                }
+            } catch (error) {
+                this.logger.error('Failed to read session index for cascade delete', { sessionId, error });
+            }
+        }
+        for (const childId of childIds) {
+            await this.deleteSession(childId);
+        }
+
         const sessionIndex = this._sessions.findIndex(candidate => candidate.id === sessionId);
 
         // If session is in memory, remove it
@@ -458,9 +483,14 @@ export class ChatServiceImpl implements ChatService {
         // Store session with title, pinned agent info, last interaction timestamp, and error state
         const lastRequest = session.model.getRequests().at(-1);
         const hasError = lastRequest?.response.isComplete === true && lastRequest?.response.isError === true;
-        return this.sessionStore.storeSessions(
-            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id, lastInteraction: session.lastInteraction?.getTime(), hasError }
-        ).catch(error => {
+        return this.sessionStore.storeSessions({
+            model: session.model,
+            title: session.title,
+            pinnedAgentId: session.pinnedAgent?.id,
+            lastInteraction: session.lastInteraction?.getTime(),
+            hasError,
+            rootSessionId: session.rootSessionId
+        }).catch(error => {
             this.logger.error('Failed to store chat sessions', error);
         });
     }
@@ -517,8 +547,10 @@ export class ChatServiceImpl implements ChatService {
             lastInteraction: new Date(serialized.saveDate),
             model,
             isActive: false,
-            pinnedAgent
+            pinnedAgent,
+            rootSessionId: serialized.rootSessionId
         };
+        session.model.rootSessionId = serialized.rootSessionId;
         this._sessions.push(session);
         this.setupAutoSaveForSession(session);
         this.onSessionEventEmitter.fire({ type: 'created', sessionId: session.id });

--- a/packages/ai-chat/src/common/chat-session-store.ts
+++ b/packages/ai-chat/src/common/chat-session-store.ts
@@ -28,6 +28,8 @@ export interface ChatModelWithMetadata {
     lastInteraction?: number;
     /** Whether the last request ended with an error. */
     hasError?: boolean;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
 }
 
 export interface ChatSessionStore {
@@ -75,4 +77,6 @@ export interface ChatSessionMetadata {
     pinnedAgentId?: string;
     /** Whether the last request ended with an error. */
     hasError?: boolean;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
 }

--- a/packages/ai-ide/src/browser/chat-session-item.tsx
+++ b/packages/ai-ide/src/browser/chat-session-item.tsx
@@ -45,6 +45,19 @@ export interface ChatSessionItemProps {
     actions?: ChatSessionItemAction[];
     /** Invoked when an action is triggered, with the action and this item's session. */
     onAction?: (action: ChatSessionItemAction, session: ChatSessionMetadata) => void;
+    /**
+     * Whether this session has child sessions. The children themselves are rendered separately by
+     * the parent list; this only drives the expand/collapse toggle.
+     */
+    hasChildren?: boolean;
+    /** Whether this item is a child of a parent session. */
+    isChild?: boolean;
+    /** Depth level for indentation. */
+    depth?: number;
+    /** Whether the parent session is expanded. */
+    isExpanded?: boolean;
+    /** Called when the user toggles the expand/collapse state. */
+    onToggleExpand?: () => void;
 }
 
 /** Subscribes the component to the unread flag for one session. */
@@ -92,7 +105,11 @@ export interface ChatSessionItemComponentProps extends ChatSessionItemProps {
 }
 
 export function ChatSessionItem(props: ChatSessionItemComponentProps): React.ReactElement {
-    const { session, isRestored, chatService, chatAgentService, hoverService, markdownRenderer, unreadState, onClick, actions, onAction, formatTimeAgo } = props;
+    const {
+        session, isRestored, chatService, chatAgentService, hoverService, markdownRenderer, unreadState,
+        onClick, actions, onAction, formatTimeAgo, hasChildren, isChild, depth, isExpanded, onToggleExpand
+    } = props;
+    const currentDepth = depth ?? 0;
 
     // eslint-disable-next-line no-null/no-null
     const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -196,6 +213,7 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
         : nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input');
     const itemClasses = [
         'theia-chat-session-item',
+        isChild && 'theia-chat-session-item-child',
         isWaitingForInput && 'theia-chat-session-item-attention',
         showWorking && 'theia-chat-session-item-working',
         hasError && !isWorking && 'theia-chat-session-item-error',
@@ -213,26 +231,52 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
             className={itemClasses}
             role="button"
             tabIndex={0}
+            style={{ '--tree-indent': `${currentDepth * 12}px` } as React.CSSProperties}
             onClick={onClick}
             onKeyDown={handleKeyDown}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             onMouseOver={handleMouseOver}>
             <div className="theia-chat-session-item-icon-col">
-                {isRestored ? (
-                    <span className={`${codicon('archive')} theia-chat-session-item-archive-icon`}
-                        title={nls.localize('theia/ai/ide/restoredSession', 'Restored session')} />
+                {hasChildren ? (
+                    <span className="theia-chat-session-item-expand-icon"
+                        onClick={e => {
+                            e.stopPropagation();
+                            onToggleExpand?.();
+                        }}
+                        onKeyDown={e => {
+                            if (isActivationKey(e)) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onToggleExpand?.();
+                            }
+                        }}
+                        onMouseDown={e => e.preventDefault()}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={isExpanded}
+                        aria-label={isExpanded ? nls.localizeByDefault('Collapse') : nls.localizeByDefault('Expand')}>
+                        <span className={`codicon ${isExpanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
+                    </span>
                 ) : (
-                    <span className={`theia-chat-session-item-agent-icon ${iconClass}`} />
+                    <span className="theia-chat-session-item-expand-icon theia-chat-session-item-expand-placeholder" aria-hidden="true" />
                 )}
-                {showUnread && (
-                    <span className="theia-chat-session-item-unread-dot"
-                        aria-label={nls.localize('theia/ai/ide/tooltip/unread', 'Unread')} />
-                )}
-                {isWaitingForInput && (
-                    <span className="theia-chat-session-item-attention-dot"
-                        aria-label={attentionLabel} />
-                )}
+                <span className="theia-chat-session-item-status-icon">
+                    {isRestored ? (
+                        <span className={`${codicon('archive')} theia-chat-session-item-archive-icon`}
+                            title={nls.localize('theia/ai/ide/restoredSession', 'Restored session')} />
+                    ) : (
+                        <span className={`theia-chat-session-item-agent-icon ${iconClass}`} />
+                    )}
+                    {showUnread && (
+                        <span className="theia-chat-session-item-unread-dot"
+                            aria-label={nls.localize('theia/ai/ide/tooltip/unread', 'Unread')} />
+                    )}
+                    {isWaitingForInput && (
+                        <span className="theia-chat-session-item-attention-dot"
+                            aria-label={attentionLabel} />
+                    )}
+                </span>
             </div>
             <div className="theia-chat-session-item-content">
                 <div className="theia-chat-session-item-title-line">

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -40,6 +40,13 @@ export interface SectionedSessions {
     restored: ChatSessionMetadata[];
 }
 
+/** A session row with its optional children. */
+export interface SessionRow {
+    session: ChatSessionMetadata;
+    isRestored: boolean;
+    children: SessionRow[];
+}
+
 export interface VisibleSessionSlots {
     activeCount: number;
     restoredCount: number;
@@ -69,19 +76,31 @@ export function computeVisibleSessionSlots(activeTotal: number, restoredTotal: n
 }
 
 interface SessionsListProps {
-    sections: SectionedSessions;
+    rows: SessionRow[];
     /** Total cap on items shown on the home view; overflow surfaces via the Browse all link. */
     maxSessions: number;
-    renderItem: (session: ChatSessionMetadata, isRestored: boolean) => React.ReactNode;
+    renderRow: (row: SessionRow) => React.ReactNode;
     onBrowseAll: () => void;
 }
 
-function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: SessionsListProps): React.ReactElement {
-    const total = sections.active.length + sections.restored.length;
-    const { activeCount, restoredCount } = computeVisibleSessionSlots(sections.active.length, sections.restored.length, maxSessions);
-    const activeVisible = sections.active.slice(0, activeCount);
-    const restoredVisible = sections.restored.slice(0, restoredCount);
-    const hiddenCount = total - activeVisible.length - restoredVisible.length;
+function SessionsList({ rows, maxSessions, renderRow, onBrowseAll }: SessionsListProps): React.ReactElement {
+    // Children are rendered inline by their parent row, so only top-level rows appear in the
+    // sections. A child whose root session is not in the list falls back to top-level (orphan).
+    const topLevelRows = rows.filter(row => {
+        if (!row.session.rootSessionId) {
+            return true;
+        }
+        const rootId = row.session.rootSessionId;
+        return !rows.some(r => r.session.sessionId === rootId);
+    });
+
+    const activeRows = topLevelRows.filter(row => !row.isRestored);
+    const restoredRows = topLevelRows.filter(row => row.isRestored);
+
+    const { activeCount, restoredCount } = computeVisibleSessionSlots(activeRows.length, restoredRows.length, maxSessions);
+    const activeVisible = activeRows.slice(0, activeCount);
+    const restoredVisible = restoredRows.slice(0, restoredCount);
+    const hiddenCount = topLevelRows.length - activeVisible.length - restoredVisible.length;
 
     return (
         <div className="theia-WelcomeMessage-SessionsList">
@@ -90,7 +109,7 @@ function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: Sessio
                     <div className="theia-WelcomeMessage-SessionsHeader">
                         {nls.localizeByDefault('Active')}
                     </div>
-                    {activeVisible.map(s => renderItem(s, false))}
+                    {activeVisible.map(row => renderRow(row))}
                 </div>
             )}
             {restoredVisible.length > 0 && (
@@ -98,7 +117,7 @@ function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: Sessio
                     <div className="theia-WelcomeMessage-SessionsHeader">
                         {nls.localize('theia/ai/ide/sectionRestored', 'Restored')}
                     </div>
-                    {restoredVisible.map(s => renderItem(s, true))}
+                    {restoredVisible.map(row => renderRow(row))}
                 </div>
             )}
             {hiddenCount > 0 && (
@@ -168,6 +187,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     /** Persisted sessions index sorted newest first. May include duplicates of active sessions. */
     protected _persistedSessions: ChatSessionMetadata[] = [];
+
+    /** Expanded root session IDs (default collapsed). */
+    protected expandedRoots = new Set<string>();
 
     protected readonly onStateChangedEmitter = new Emitter<void>();
     readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
@@ -335,7 +357,8 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                 saveDate: session.lastInteraction?.getTime() ?? Date.now(),
                 location: session.model.location,
                 pinnedAgentId: session.pinnedAgent?.id,
-                hasError: session.model.status === 'failed'
+                hasError: session.model.status === 'failed',
+                rootSessionId: session.rootSessionId
             }));
         const restored = this._persistedSessions.filter(metadata => !activeIds.has(metadata.sessionId));
         return { active, restored };
@@ -356,13 +379,29 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
         const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
+        // Build one row per session (carrying its own restored flag), then nest each child row under
+        // its root session's row via rootSessionId. Children keep their row so the restored flag and
+        // actions are computed once here rather than recomputed per child during rendering.
+        const allSessions = [...sections.active, ...sections.restored];
+        const activeIds = new Set(sections.active.map(s => s.sessionId));
+        const rowsById = new Map<string, SessionRow>();
+        for (const session of allSessions) {
+            rowsById.set(session.sessionId, { session, isRestored: !activeIds.has(session.sessionId), children: [] });
+        }
+        for (const session of allSessions) {
+            if (session.rootSessionId) {
+                rowsById.get(session.rootSessionId)?.children.push(rowsById.get(session.sessionId)!);
+            }
+        }
+        const rows = [...rowsById.values()];
+
         return (
             <div className="theia-WelcomeMessage" key="sessions-section">
                 <div className="theia-WelcomeMessage-SessionsSection">
                     <SessionsList
-                        sections={sections}
+                        rows={rows}
                         maxSessions={maxSessions}
-                        renderItem={this.renderSessionItem}
+                        renderRow={this.renderSessionRow}
                         onBrowseAll={this.handleBrowseAllChats}
                     />
                 </div>
@@ -370,27 +409,66 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         );
     }
 
-    protected renderSessionItem = (session: ChatSessionMetadata, isRestored: boolean): React.ReactNode => {
-        const actions = this.chatSessionItemActionContributions
+    protected toggleExpand = (sessionId: string): void => {
+        this.expandedRoots = new Set(this.expandedRoots);
+        if (this.expandedRoots.has(sessionId)) {
+            this.expandedRoots.delete(sessionId);
+        } else {
+            this.expandedRoots.add(sessionId);
+        }
+        this.onStateChangedEmitter.fire();
+    };
+
+    /** Collects the enabled session-item actions for a session, sorted by priority. */
+    protected getSessionActions(session: ChatSessionMetadata): ChatSessionItemAction[] {
+        return this.chatSessionItemActionContributions
             .getContributions()
             .flatMap(c => c.getActions(session))
             .filter(action => this.commandRegistry.isEnabled(action.commandId, session))
             .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+    }
+
+    protected renderSessionRow = (row: SessionRow): React.ReactNode => {
+        const hasChildren = row.children.length > 0;
+        const isExpanded = hasChildren && this.expandedRoots.has(row.session.sessionId);
+
         return (
-            <ChatSessionItem
-                key={session.sessionId}
-                session={session}
-                isRestored={isRestored}
-                chatService={this.chatService}
-                chatAgentService={this.chatAgentService}
-                hoverService={this.hoverService}
-                markdownRenderer={this.markdownRenderer}
-                unreadState={this}
-                onClick={() => this.handleSessionItemClick(session.sessionId)}
-                actions={actions}
-                onAction={this.handleSessionItemAction}
-                formatTimeAgo={date => formatTimeAgo(date)}
-            />
+            <React.Fragment key={row.session.sessionId}>
+                <ChatSessionItem
+                    session={row.session}
+                    isRestored={row.isRestored}
+                    chatService={this.chatService}
+                    chatAgentService={this.chatAgentService}
+                    hoverService={this.hoverService}
+                    markdownRenderer={this.markdownRenderer}
+                    unreadState={this}
+                    onClick={() => this.handleSessionItemClick(row.session.sessionId)}
+                    actions={this.getSessionActions(row.session)}
+                    onAction={this.handleSessionItemAction}
+                    formatTimeAgo={date => formatTimeAgo(date)}
+                    hasChildren={hasChildren}
+                    isExpanded={isExpanded}
+                    onToggleExpand={hasChildren ? () => this.toggleExpand(row.session.sessionId) : undefined}
+                />
+                {isExpanded && row.children.map(child => (
+                    <ChatSessionItem
+                        key={child.session.sessionId}
+                        session={child.session}
+                        isRestored={child.isRestored}
+                        chatService={this.chatService}
+                        chatAgentService={this.chatAgentService}
+                        hoverService={this.hoverService}
+                        markdownRenderer={this.markdownRenderer}
+                        unreadState={this}
+                        onClick={() => this.handleSessionItemClick(child.session.sessionId)}
+                        actions={this.getSessionActions(child.session)}
+                        onAction={this.handleSessionItemAction}
+                        formatTimeAgo={date => formatTimeAgo(date)}
+                        isChild={true}
+                        depth={1}
+                    />
+                ))}
+            </React.Fragment>
         );
     };
 

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1169,7 +1169,7 @@
   display: flex;
   align-items: center;
   gap: var(--theia-ui-padding);
-  padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 2);
+  padding: var(--theia-ui-padding);
   border-radius: 3px;
   cursor: pointer;
   outline: none;
@@ -1187,11 +1187,18 @@
 }
 
 .theia-chat-session-item-icon-col {
-  position: relative;
   display: inline-flex;
   align-items: center;
   gap: calc(var(--theia-ui-padding) / 2);
   flex-shrink: 0;
+}
+
+/* Positioning context for the unread/attention badges so they anchor to the status icon itself
+   rather than to the whole column (which now also holds the expand toggle to the left). */
+.theia-chat-session-item-status-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .theia-chat-session-item-unread-dot,
@@ -1244,9 +1251,55 @@
    foreground so they stay readable on the highlighted background. */
 .theia-chat-session-item:focus .theia-chat-session-item-agent-icon,
 .theia-chat-session-item:focus .theia-chat-session-item-archive-icon,
+.theia-chat-session-item:focus .theia-chat-session-item-expand-icon,
 .theia-chat-session-item:focus-within .theia-chat-session-item-agent-icon,
-.theia-chat-session-item:focus-within .theia-chat-session-item-archive-icon {
+.theia-chat-session-item:focus-within .theia-chat-session-item-archive-icon,
+.theia-chat-session-item:focus-within .theia-chat-session-item-expand-icon {
   color: inherit;
+}
+
+/* Expand/collapse toggle shown next to the agent icon on parent sessions.
+   Non-parent rows render a same-sized placeholder so agent icons stay aligned. */
+.theia-chat-session-item-expand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: content-box;
+  width: var(--theia-ui-font-size0);
+  padding: calc(var(--theia-ui-padding) / 2);
+  border-radius: 3px;
+  color: var(--theia-descriptionForeground);
+  font-size: var(--theia-ui-font-size0);
+  outline: none;
+}
+
+.theia-chat-session-item-expand-icon:not(.theia-chat-session-item-expand-placeholder) {
+  cursor: pointer;
+}
+
+.theia-chat-session-item-expand-icon:not(.theia-chat-session-item-expand-placeholder):hover {
+  color: var(--theia-icon-foreground);
+  background-color: var(--theia-toolbar-hoverBackground, var(--theia-list-hoverBackground));
+}
+
+/* Only show a focus ring for keyboard focus, not on pointer clicks. */
+.theia-chat-session-item-expand-icon:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+}
+
+/* The placeholder only reserves layout space and must not be interactive. */
+.theia-chat-session-item-expand-placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* Child session indentation */
+.theia-chat-session-item-child {
+  padding-left: calc(var(--tree-indent, 0px) + var(--theia-ui-padding) * 3);
+}
+
+.theia-chat-session-item-child .theia-chat-session-item-content {
+  font-size: calc(var(--theia-ui-font-size1) * 0.95);
 }
 
 .theia-chat-session-item-content {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Group delegated chat sessions under their root session in the welcome screen session list, with a collapsible parent/child hierarchy.

- Track rootSessionId on chat sessions and thread it through serialization, the chat service, and the session store so the welcome view can reconstruct the parent/child relationship.
- Render parent sessions with a collapsible expand/collapse toggle shown next to the agent icon; childless rows reserve an equal-sized placeholder so agent icons stay aligned across all rows.
- Indent child sessions and give the expand toggle a larger hit area, a keyboard-only focus ring, and selection-aware coloring so it stays visible when the row is focused.
- Keep the Active and Restored sections in the welcome list, splitting top-level rows by section while children render inline under their parent.
- Exclude child sessions from the 'Browse all chats' quick input, for both active and restored sessions, so they only appear nested under their parent.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build (npm run build:browser) and start the browser app; create a delegated chat so a
  parent session gets child sessions.
  2. In the welcome session list, confirm parents show the agent icon plus an expand chevron
  (childless rows keep icons aligned via a placeholder), and toggling shows/hides indented
  children.
  3. Focus a parent row: the chevron stays visible on the selection background, and clicking it
  shows no focus ring.
  4. Confirm both Active and Restored sections render, and that child sessions appear only
  nested under their parent — never standalone in the list or the "Browse all chats" quick
  input.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
